### PR TITLE
bump version

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -104,7 +104,6 @@ jobs:
             HTTPS_PROXY=${{ env.https_proxy }}
             NO_PROXY=${{ env.no_proxy }}
           push: true
-          context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ steps.more-meta.outputs.PRIMARY_TAG_SHORT }}:buildcache

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -107,5 +107,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ steps.more-meta.outputs.PRIMARY_TAG_SHORT }}:buildcache
-          cache-to: ${{ github.event_name == 'push' && format('type=registry,image-manifest=true,ref={0}:buildcache,mode=max', steps.more-meta.outputs.PRIMARY_TAG_SHORT) || '' }}
-  
+          cache-to: ${{ github.event_name == 'pull_request_target' && '' || format('type=registry,image-manifest=true,ref={0}:buildcache,mode=max', steps.more-meta.outputs.PRIMARY_TAG_SHORT) }}

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -107,5 +107,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ steps.more-meta.outputs.PRIMARY_TAG_SHORT }}:buildcache
-          cache-to: ${{ format('refs/heads/{0}', github.event.repository.default_branch) == github.ref && format('type=registry,image-manifest=true,ref={0}:buildcache,mode=max', steps.more-meta.outputs.PRIMARY_TAG_SHORT) || '' }}
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,image-manifest=true,ref={0}:buildcache,mode=max', steps.more-meta.outputs.PRIMARY_TAG_SHORT) || '' }}
   

--- a/README.md
+++ b/README.md
@@ -276,8 +276,8 @@ Or if you'd like to get your hands dirty:
 ```python
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-model = AutoModelForCausalLM.from_pretrained("01-ai/Yi-34B", device_map="auto", torch_dtype="auto", trust_remote_code=True)
-tokenizer = AutoTokenizer.from_pretrained("01-ai/Yi-34B", trust_remote_code=True)
+model = AutoModelForCausalLM.from_pretrained("01-ai/Yi-34B", device_map="auto", torch_dtype="auto")
+tokenizer = AutoTokenizer.from_pretrained("01-ai/Yi-34B")
 inputs = tokenizer("There's a place where time stands still. A place of breath taking wonder, but also", return_tensors="pt")
 max_length = 256
 

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -13,7 +13,7 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: a3d705cbd778a884ab398d7b1fc2255ca43862c90c83fe276158c78aa2b03a79
+    linux-64: 34917454cc3b52bed3e7b3da235c906f4609f0f3887b9a16690d8989475bce2b
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -38,14 +38,14 @@ package:
   category: main
   optional: false
 - name: ca-certificates
-  version: 2023.7.22
+  version: 2023.11.17
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.11.17-hbcca054_0.conda
   hash:
-    md5: a73ecd2988327ad4c8f2c331482917f2
-    sha256: 525b7b6b5135b952ec1808de84e5eca57c7c7ff144e29ef3e96ae4040ff432c1
+    md5: 01ffc8d36f9eba0ce0b3c1955fa780ee
+    sha256: fb4b9f4b7d885002db0b93e22f44b5b03791ef3d4efdc9d0662185a0faafd6b6
   category: main
   optional: false
 - name: cuda-cudart
@@ -137,25 +137,25 @@ package:
   category: main
   optional: false
 - name: libcufile
-  version: 1.8.0.34
+  version: 1.8.1.2
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/nvidia/linux-64/libcufile-1.8.0.34-0.tar.bz2
+  url: https://conda.anaconda.org/nvidia/linux-64/libcufile-1.8.1.2-0.tar.bz2
   hash:
-    md5: 6c5b94a8881d400a0fcb77ba2ffe343d
-    sha256: ea341c09e92aa877baad574fbe658fcdf094d3960e086dfdee1d4356d2b91035
+    md5: 9216c3ab5eb551bb7c2c4f604b4e7614
+    sha256: f399e21e2d8a286d74354c0df94635f259cfb6649031a8f48a5654f97387014f
   category: main
   optional: false
 - name: libcurand
-  version: 10.3.4.52
+  version: 10.3.4.101
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/nvidia/linux-64/libcurand-10.3.4.52-0.tar.bz2
+  url: https://conda.anaconda.org/nvidia/linux-64/libcurand-10.3.4.101-0.tar.bz2
   hash:
-    md5: 184f8dc889f632f17c6fe56f04d30107
-    sha256: b778aaffc50c348220c6d523c8063ce567a8aca8bd210c68bca9cabba9877262
+    md5: c19aee1cc95a33b3aadc62113f1e57f2
+    sha256: 0c001fd158a81b5fff10cd711805f87c8d11a9f5794ea9fa5aa76aef129c0b48
   category: main
   optional: false
 - name: libcusolver
@@ -342,15 +342,15 @@ package:
   category: main
   optional: false
 - name: c-ares
-  version: 1.21.0
+  version: 1.22.1
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.21.0-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.22.1-hd590300_0.conda
   hash:
-    md5: c06fa0440048270817b9e3142cc661bf
-    sha256: dfe0e81d5462fced79fd0f99edeec94c9b27268cb04238638180981af2f889f1
+    md5: 8430bd266c7b2cfbda403f7585d5ee86
+    sha256: d41cf87938ba66de538b91afed3ece9b4cf5ed082a7d1c1add46b70f482f34b9
   category: main
   optional: false
 - name: cudatoolkit
@@ -614,17 +614,17 @@ package:
   category: main
   optional: false
 - name: nccl
-  version: 2.19.3.1
+  version: 2.19.4.1
   manager: conda
   platform: linux-64
   dependencies:
     cuda-version: '>=11.8,<12.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nccl-2.19.3.1-h6103f9b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/nccl-2.19.4.1-h6103f9b_0.conda
   hash:
-    md5: 5b4426d8e0534cd844924728d2137666
-    sha256: 0464f985f4e1ab8ccbb4b3d169ece570a3ac6e6302d87e1da7b0ef35bc196249
+    md5: 2946f0e841f1f0be90c90bc67877d417
+    sha256: bb8ae7c3004065f44798aaf75f5b25e5b6262437c6581d0814f60c0960e62359
   category: main
   optional: false
 - name: ncurses
@@ -640,16 +640,16 @@ package:
   category: main
   optional: false
 - name: openssl
-  version: 3.1.4
+  version: 3.2.0
   manager: conda
   platform: linux-64
   dependencies:
     ca-certificates: ''
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.4-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.0-hd590300_0.conda
   hash:
-    md5: 412ba6938c3e2abaca8b1129ea82e238
-    sha256: d15b3e83ce66c6f6fbb4707f2f5c53337124c01fb03bfda1cf25c5b41123efc7
+    md5: 68223671a2b68cdf7241eb4679ab2dd4
+    sha256: a8ca7c31be33894bd70bb34786d1a8c26ae650382411250b61f6b5249b69a23e
   category: main
   optional: false
 - name: rdma-core
@@ -792,10 +792,10 @@ package:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cudnn-8.8.0.121-h838ba91_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cudnn-8.8.0.121-h838ba91_4.conda
   hash:
-    md5: 23fe960de88644a27bf747f4c37dcac1
-    sha256: 0e591d4350c6f75af66533d944659fa51f562a259e06342e9a2f010d6f1f9b5c
+    md5: a465de35ca7a3b05f43bf7267e8e8ebb
+    sha256: f3fe3a6e0d6de423cadd6de644680f71d97b18becef225bcb9aa4f570e623a1e
   category: main
   optional: false
 - name: glog
@@ -923,16 +923,16 @@ package:
   category: main
   optional: false
 - name: libsqlite
-  version: 3.44.0
+  version: 3.44.2
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.0-h2797004_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.2-h2797004_0.conda
   hash:
-    md5: b58e6816d137f3aabf77d341dd5d732b
-    sha256: 74ef5dcb900c38bec53140036e5e2a9cc7ffcd806da479ea2305f962a358a259
+    md5: 3b6a9f225c3dbe0d24f4fedd4625c5bf
+    sha256: ee2c4d724a3ed60d5b458864d66122fb84c6ce1df62f735f90d8db17b66cd88a
   category: main
   optional: false
 - name: libssh2
@@ -950,7 +950,7 @@ package:
   category: main
   optional: false
 - name: libxml2
-  version: 2.11.5
+  version: 2.11.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -959,10 +959,10 @@ package:
     libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.5-h232c23b_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.6-h232c23b_0.conda
   hash:
-    md5: f3858448893839820d4bcfb14ad3ecdf
-    sha256: 1b3cb6864de1a558ea5fb144c780121d52507837d15df0600491d8ed92cff90c
+    md5: 427a3e59d66cb5d145020bd9c6493334
+    sha256: e6183d5e57ee48cc1fc4340477c31a6bd8be4d3ba5dded82cbca0d5280591086
   category: main
   optional: false
 - name: mpfr
@@ -1047,7 +1047,7 @@ package:
   category: main
   optional: false
 - name: aws-c-io
-  version: 0.13.35
+  version: 0.13.36
   manager: conda
   platform: linux-64
   dependencies:
@@ -1055,10 +1055,10 @@ package:
     aws-c-common: '>=0.9.8,<0.9.9.0a0'
     libgcc-ng: '>=12'
     s2n: '>=1.3.56,<1.3.57.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.35-hc23c90e_8.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.36-hc23c90e_0.conda
   hash:
-    md5: 4cabe68190c1ff4c72154c0a7d2e980c
-    sha256: 89103265c27cb5ad67a0f6b67149532e7addae4b6ddfb704e77f0369f5520591
+    md5: 57259ec9cdbba3e4897e950dd976c93d
+    sha256: b3fe3214b11f3cf3c631bef0be09f88610103c0262225a368914ce149533900d
   category: main
   optional: false
 - name: krb5
@@ -1108,17 +1108,17 @@ package:
   category: main
   optional: false
 - name: libopenblas
-  version: 0.3.24
+  version: 0.3.25
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libgfortran-ng: ''
     libgfortran5: '>=12.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.25-pthreads_h413a1c8_0.conda
   hash:
-    md5: 6e4ef6ca28655124dcde9bd500e44c32
-    sha256: c8e080ae4d57506238023e98869928ae93564e6407ef5b0c4d3a337e8c2b7662
+    md5: d172b34a443b95f86089e8229ddc9a17
+    sha256: 628564517895ee1b09cf72c817548bd80ef1acce6a8214a8520d9f7b44c4cfaf
   category: main
   optional: false
 - name: libsentencepiece
@@ -1153,16 +1153,16 @@ package:
   category: main
   optional: false
 - name: llvm-openmp
-  version: 17.0.4
+  version: 17.0.5
   manager: conda
   platform: linux-64
   dependencies:
     libzlib: '>=1.2.13,<1.3.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-17.0.4-h4dfa4b3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-17.0.5-h4dfa4b3_0.conda
   hash:
-    md5: c560d4ecf0d3536108aa4de0222942d3
-    sha256: ef5c3a2eb09239a95fbcd4ec9272cb05a950382f52968c2d5e09dfe72488bf63
+    md5: 799291c22ec87a0c86c0a4fc0e22b1c5
+    sha256: ef97ef1a8cbdb7862bc5a6f2aee17e289e355cb6f26a0f3b0549aedc9c174853
   category: main
   optional: false
 - name: mpc
@@ -1180,7 +1180,7 @@ package:
   category: main
   optional: false
 - name: orc
-  version: 1.9.0
+  version: 1.9.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -1191,10 +1191,10 @@ package:
     lz4-c: '>=1.9.3,<1.10.0a0'
     snappy: '>=1.1.10,<2.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.0-h4b38347_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.2-h4b38347_0.conda
   hash:
-    md5: f348d6a6bb3687dfead7c595f905732b
-    sha256: af3587f3b9a892be828d159b78379bdcd03b933c9fefddfcf105541421b77d48
+    md5: 6e6f990b097d3e237e18a8e321d08484
+    sha256: a06dd76bc0f2f99f5db5e348298c906007c3aa9e31b963f71d16e63f770b900b
   category: main
   optional: false
 - name: python
@@ -1253,14 +1253,14 @@ package:
   platform: linux-64
   dependencies:
     aws-c-common: '>=0.9.8,<0.9.9.0a0'
-    aws-c-io: '>=0.13.35,<0.13.36.0a0'
+    aws-c-io: '>=0.13.36,<0.13.37.0a0'
     aws-checksums: '>=0.1.17,<0.1.18.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.3.2-hae413d4_6.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.3.2-h1fff966_7.conda
   hash:
-    md5: b4e69f0e7f832dc901bd585f353487f0
-    sha256: b7b00593f4cd835780d3a4f61f6f77181b33b8e85cc0f78d9cb48dc1d84e8443
+    md5: 7badad50132f03325f1060dc0a006465
+    sha256: abade13c6c6b480bc68ba11d2616f81951207ce44115ac10d237c38251641380
   category: main
   optional: false
 - name: aws-c-http
@@ -1271,12 +1271,12 @@ package:
     aws-c-cal: '>=0.6.9,<0.6.10.0a0'
     aws-c-common: '>=0.9.8,<0.9.9.0a0'
     aws-c-compression: '>=0.2.17,<0.2.18.0a0'
-    aws-c-io: '>=0.13.35,<0.13.36.0a0'
+    aws-c-io: '>=0.13.36,<0.13.37.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.7.14-h162056d_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.7.14-hc86c171_2.conda
   hash:
-    md5: e1b49ef8ddc4faca06a63a7e25da644f
-    sha256: dc4cda9ffef3b5859c5943f010e947e082315e7d84eb1f5e0b3cd58565eaf405
+    md5: e092fb5c53b2915be20b19e8e31b016e
+    sha256: e29a5b81731995634338ced49d241c77f820df37977ab932a637351efc94adba
   category: main
   optional: false
 - name: brotli-python
@@ -1295,15 +1295,15 @@ package:
   category: main
   optional: false
 - name: certifi
-  version: 2023.7.22
+  version: 2023.11.17
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.11.17-pyhd8ed1ab_0.conda
   hash:
-    md5: 7f3dbc9179b4dde7da98dfb151d0ad22
-    sha256: db66e31866ff4250c190788769e3a8a1709237c3e9c38d7143aae95ab75fcb31
+    md5: 2011bcf45376341dd1d690263fdbc789
+    sha256: afa22b77128a812cb57bc707c297d926561bd225a3d9dd74205d87a3b2d14a96
   category: main
   optional: false
 - name: charset-normalizer
@@ -1460,15 +1460,15 @@ package:
   category: main
   optional: false
 - name: idna
-  version: '3.4'
+  version: '3.6'
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
   hash:
-    md5: 34272b248891bddccc64479f9a7fffed
-    sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
+    md5: 1a76f09108576397c41c0b0c5bd84134
+    sha256: 6ee4c986d69ce61e60a20b2459b6f2027baeba153f0a64995fd3cb47c2cc7e07
   category: main
   optional: false
 - name: libblas
@@ -1476,11 +1476,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libopenblas: '>=0.3.24,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-19_linux64_openblas.conda
+    libopenblas: '>=0.3.25,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-20_linux64_openblas.conda
   hash:
-    md5: 420f4e9be59d0dc9133a0f43f7bab3f3
-    sha256: b1311b9414559c5760b08a32e0382ca27fa302c967968aa6f78e042519f728ce
+    md5: 2b7bb4f7562c8cf334fc2e20c2d28abc
+    sha256: 8a0ee1de693a9b3da4a11b95ec81b40dd434bd01fa1f5f38f8268cd2146bf8f0
   category: main
   optional: false
 - name: libcurl
@@ -1502,11 +1502,11 @@ package:
   category: main
   optional: false
 - name: libgrpc
-  version: 1.59.2
+  version: 1.59.3
   manager: conda
   platform: linux-64
   dependencies:
-    c-ares: '>=1.20.1,<2.0a0'
+    c-ares: '>=1.21.0,<2.0a0'
     libabseil: '>=20230802.1,<20230803.0a0'
     libgcc-ng: '>=12'
     libprotobuf: '>=4.24.4,<4.24.5.0a0'
@@ -1515,10 +1515,10 @@ package:
     libzlib: '>=1.2.13,<1.3.0a0'
     openssl: '>=3.1.4,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.59.2-hd6c4280_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.59.3-hd6c4280_0.conda
   hash:
-    md5: dd26e7127a7b08068b52181f47849f04
-    sha256: 4ac31c7667fb0940856afc4b8ea58d8f1cb18db3cdf41729aa7d2c7f7a5e6429
+    md5: 896c137eaf0c22f2fef58332eb4a4b83
+    sha256: 3f95a2792e565b628cb284de92017a37a1cddc4a3f83453b8f75d9adc9f8cfdd
   category: main
   optional: false
 - name: markupsafe
@@ -1802,15 +1802,15 @@ package:
   category: main
   optional: false
 - name: wheel
-  version: 0.41.3
+  version: 0.42.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3fc026b9c87d091c4b34a6c997324ae8
-    sha256: 84c3b57fba778add2bd47b7cc70e86f746d2c55549ffd2ccb6f3d6bf7c94d21d
+    md5: 1cdea58981c5cbc17b51973bcaddcea7
+    sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
   category: main
   optional: false
 - name: zipp
@@ -1839,35 +1839,35 @@ package:
   category: main
   optional: false
 - name: aws-c-auth
-  version: 0.7.6
+  version: 0.7.7
   manager: conda
   platform: linux-64
   dependencies:
     aws-c-cal: '>=0.6.9,<0.6.10.0a0'
     aws-c-common: '>=0.9.8,<0.9.9.0a0'
     aws-c-http: '>=0.7.14,<0.7.15.0a0'
-    aws-c-io: '>=0.13.35,<0.13.36.0a0'
+    aws-c-io: '>=0.13.36,<0.13.37.0a0'
     aws-c-sdkutils: '>=0.1.12,<0.1.13.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.6-h37ad1db_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.7-h4faf3ed_1.conda
   hash:
-    md5: 31836ccf72bc70ce2ec38a2ec2c8b504
-    sha256: 6f44ef79e2ab5005961847cdefd2a71aa3a33c741adc77e774ac9dbedd9a2f81
+    md5: e2a9f779fafe385cd516c079e7c9a36b
+    sha256: 2647adb3ef4373e545308791020d6fbbeff4b57a3a1bb9f82dfc89ddf56e458e
   category: main
   optional: false
 - name: aws-c-mqtt
-  version: 0.9.9
+  version: 0.9.10
   manager: conda
   platform: linux-64
   dependencies:
     aws-c-common: '>=0.9.8,<0.9.9.0a0'
     aws-c-http: '>=0.7.14,<0.7.15.0a0'
-    aws-c-io: '>=0.13.35,<0.13.36.0a0'
+    aws-c-io: '>=0.13.36,<0.13.37.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.9.9-h1387108_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.9.10-hba57965_1.conda
   hash:
-    md5: d03181571be036cfbe7accf52256efe7
-    sha256: 1df6ad0f5db319090718f5d4575b8829ff5aa5b663c8580e191fa9005e71072d
+    md5: c458f86f2d52f04a588c0ce72c8b2bce
+    sha256: 803ddbb520a706f8b43283f37640e1b37b132b399ceef76abb8f4b309933400e
   category: main
   optional: false
 - name: coloredlogs
@@ -1928,10 +1928,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-19_linux64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-20_linux64_openblas.conda
   hash:
-    md5: d12374af44575413fbbd4a217d46ea33
-    sha256: 84fddccaf58f42b07af7fb42512bd617efcb072f17bdef27f4c1884dbd33c86a
+    md5: 36d486d72ab64ffea932329a1d3729a3
+    sha256: 0e34fb0f82262f02fcb279ab4a1db8d50875dc98e3019452f8f387e6bf3c0247
   category: main
   optional: false
 - name: libgoogle-cloud
@@ -1959,10 +1959,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-19_linux64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-20_linux64_openblas.conda
   hash:
-    md5: 9f100edf65436e3eabc2a51fc00b2c37
-    sha256: 58f402aae605ebd0932e1cbbf855cd49dcdfa2fcb6aab790a4f6068ec5937878
+    md5: 6fabc51f5e647d09cc010c40061557e0
+    sha256: ad7745b8d0f2ccb9c3ba7aaa7167d62fc9f02e45eb67172ae5f0dfb5a3b1a2cc
   category: main
   optional: false
 - name: mkl
@@ -2095,17 +2095,17 @@ package:
   category: main
   optional: false
 - name: urllib3
-  version: 2.0.7
+  version: 2.1.0
   manager: conda
   platform: linux-64
   dependencies:
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 270e71c14d37074b1d066ee21cf0c4a6
-    sha256: 9fe14735dde74278c6f1710cbe883d5710fc98501a96031dec6849a8d8a1bb11
+    md5: f8ced8ee63830dec7ecc1be048d1470a
+    sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
   category: main
   optional: false
 - name: yarl
@@ -2124,6 +2124,25 @@ package:
     sha256: f25893b4c4e4432cdfa1c19631dd503e5f197704d2b9d09624520ece9a6845f0
   category: main
   optional: false
+- name: aiohttp
+  version: 3.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aiosignal: '>=1.1.2'
+    attrs: '>=17.3.0'
+    frozenlist: '>=1.1.1'
+    libgcc-ng: '>=12'
+    multidict: '>=4.5,<7.0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    yarl: '>=1.0,<2.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.9.0-py311h459d7ec_0.conda
+  hash:
+    md5: f8622107430b609e3956250ed601ad30
+    sha256: f1e0233e814200c3bcfa081f1d0adc3200d334475aeac91917187026434a4b3f
+  category: main
+  optional: false
 - name: annotated-types
   version: 0.6.0
   manager: conda
@@ -2137,36 +2156,23 @@ package:
     sha256: 3a2c98154d95cfd54daba6b7d507d31f5ba07ac2ad955c44eb041b66563193cd
   category: main
   optional: false
-- name: async-timeout
-  version: 4.0.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=3.6.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3ce482ec3066e6d809dbbb1d1679f215
-    sha256: bd8b698e7f037a9c6107216646f1191f4f7a7fc6da6c34d1a6d4c211bcca8979
-  category: main
-  optional: false
 - name: aws-c-s3
-  version: 0.3.23
+  version: 0.4.1
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-auth: '>=0.7.6,<0.7.7.0a0'
+    aws-c-auth: '>=0.7.7,<0.7.8.0a0'
     aws-c-cal: '>=0.6.9,<0.6.10.0a0'
     aws-c-common: '>=0.9.8,<0.9.9.0a0'
     aws-c-http: '>=0.7.14,<0.7.15.0a0'
-    aws-c-io: '>=0.13.35,<0.13.36.0a0'
+    aws-c-io: '>=0.13.36,<0.13.37.0a0'
     aws-checksums: '>=0.1.17,<0.1.18.0a0'
     libgcc-ng: '>=12'
     openssl: '>=3.1.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.3.23-h7630044_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.4.1-hfadff92_0.conda
   hash:
-    md5: 76eebe9871477c883d04042758493b98
-    sha256: a145f456f0a47f8f7482ce6c23f4bfc3b71cb013598d4e1294930dcc8db56c65
+    md5: 51a03f7432cc620590f050911bd6878a
+    sha256: 71832dc68eccdb70b06fc195a4f71304893f844131d8d165b308ad34eb79dfe1
   category: main
   optional: false
 - name: importlib_metadata
@@ -2188,19 +2194,19 @@ package:
   dependencies:
     __glibc: '>=2.17'
     _openmp_mutex: '>=4.5'
-    cudatoolkit: '>=11.8,<12'
+    cudatoolkit: '>=11.2,<12'
     libblas: '>=3.9.0,<4.0a0'
     libgcc-ng: '>=12'
     liblapack: '>=3.9.0,<4.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmagma-2.7.2-h8354cda_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmagma-2.7.2-h09159a4_1.conda
   hash:
-    md5: 208b78872f519c2506b6ca1a13c11541
-    sha256: d981dae6f46ceb64fbb992cc4da5c767ea70b7836aca2b59cc9a23ce13939efc
+    md5: 76e23fe440b7cb9ab93544b57ddc1745
+    sha256: 608891658329f6dd4e2836e359ae82ad694768c829d7d29a71c7d050df3cb867
   category: main
   optional: false
 - name: numpy
-  version: 1.26.0
+  version: 1.26.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -2211,14 +2217,14 @@ package:
     libstdcxx-ng: '>=12'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.0-py311h64a7726_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.2-py311h64a7726_0.conda
   hash:
-    md5: bf16a9f625126e378302f08e7ed67517
-    sha256: 0aab5cef67cc2a1cd584f6e9cc6f2065c7a28c142d7defcb8096e8f719d9b3bf
+    md5: fd2f142dcd680413b5ede5d0fb799205
+    sha256: c68b2c0ce95b79913134ec6ba2a2f1c10adcd60133afd48e4a57fdd128b694b7
   category: main
   optional: false
 - name: pydantic-core
-  version: 2.10.1
+  version: 2.14.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -2226,10 +2232,10 @@ package:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     typing-extensions: '>=4.6.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.10.1-py311h46250e7_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.14.5-py311h46250e7_0.conda
   hash:
-    md5: 36ee4237f8f9f97adb057974e8fee4c5
-    sha256: 871ec291dd2be9a38768c63ac94f3f959a9084aa75dd09b5657fc1c6a7a73e2f
+    md5: 9b2d1233d958079649cc8f91d814e04f
+    sha256: c546a042316c34bf6b9c5e16da4e6993f6712554c0ac5ee3f49260260789c38f
   category: main
   optional: false
 - name: requests
@@ -2265,47 +2271,26 @@ package:
     sha256: 2fdc52c648c0a0d80f2f6f484cd0933f9b553d2e568bf8b63abe444974eb75b5
   category: main
   optional: false
-- name: aiohttp
-  version: 3.8.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aiosignal: '>=1.1.2'
-    async-timeout: <5.0,>=4.0.0a3
-    attrs: '>=17.3.0'
-    charset-normalizer: '>=2.0,<4.0'
-    frozenlist: '>=1.1.1'
-    libgcc-ng: '>=12'
-    multidict: '>=4.5,<7.0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    yarl: '>=1.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.8.6-py311h459d7ec_1.conda
-  hash:
-    md5: 7d4b63a745f293029b5689b0b5d8aa15
-    sha256: 690f7ca719e99d47728c392ab0f5f362013852800db41702c29d219c8e380976
-  category: main
-  optional: false
 - name: aws-crt-cpp
-  version: 0.24.5
+  version: 0.24.7
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-auth: '>=0.7.6,<0.7.7.0a0'
+    aws-c-auth: '>=0.7.7,<0.7.8.0a0'
     aws-c-cal: '>=0.6.9,<0.6.10.0a0'
     aws-c-common: '>=0.9.8,<0.9.9.0a0'
     aws-c-event-stream: '>=0.3.2,<0.3.3.0a0'
     aws-c-http: '>=0.7.14,<0.7.15.0a0'
-    aws-c-io: '>=0.13.35,<0.13.36.0a0'
-    aws-c-mqtt: '>=0.9.9,<0.9.10.0a0'
-    aws-c-s3: '>=0.3.23,<0.3.24.0a0'
+    aws-c-io: '>=0.13.36,<0.13.37.0a0'
+    aws-c-mqtt: '>=0.9.10,<0.9.11.0a0'
+    aws-c-s3: '>=0.4.1,<0.4.2.0a0'
     aws-c-sdkutils: '>=0.1.12,<0.1.13.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.24.5-h270613d_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.24.7-h97e63c7_6.conda
   hash:
-    md5: 47040d82b358ac50c8badb0f988a2b43
-    sha256: 3fca577d00c8540ace4f5e052625b8b59cecb857bb466a35792384b87b17fbe7
+    md5: f31cf00e404ba450c317d3a5ca9820b6
+    sha256: 13897adb73768128bf5110a97bc9a1a9aa3dfdd86460edd9d2af644ed89bd774
   category: main
   optional: false
 - name: huggingface_hub
@@ -2341,10 +2326,10 @@ package:
     liblapack: '>=3.9.0,<4.0a0'
     libmagma: '>=2.7.2,<2.7.3.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmagma_sparse-2.7.2-h8354cda_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmagma_sparse-2.7.2-h09b5827_1.conda
   hash:
-    md5: 1a1cc7f715e5450ed3ffe6dc74ec8edd
-    sha256: 7bc90dbbba56a3ab62993e6411986ed6c2b02fab9bc785df551c790ccf6564bb
+    md5: 4214015e0fb5df4d793b36f5879760e1
+    sha256: 8385e88b9a3d68a679a25e2826a0841d0c5052ff1bc923ac233fa344d75e7dcf
   category: main
   optional: false
 - name: pandas
@@ -2367,18 +2352,18 @@ package:
   category: main
   optional: false
 - name: pydantic
-  version: 2.4.2
+  version: 2.5.2
   manager: conda
   platform: linux-64
   dependencies:
     annotated-types: '>=0.4.0'
-    pydantic-core: 2.10.1
+    pydantic-core: 2.14.5
     python: '>=3.7'
     typing-extensions: '>=4.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.4.2-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.5.2-pyhd8ed1ab_0.conda
   hash:
-    md5: aad1d187156725d52e1f8ee7756c20f6
-    sha256: dc6330364f92de95a315a19e842a26605d6ca5c7d346e77811d42ad0438e32d8
+    md5: 3f908ebfccbfd09946961862d26bb9af
+    sha256: e3baa6424af931d8d7c5a0554b24d85faf3471df8036181d598065beed3096de
   category: main
   optional: false
 - name: aws-sdk-cpp
@@ -2389,16 +2374,16 @@ package:
     aws-c-common: '>=0.9.8,<0.9.9.0a0'
     aws-c-event-stream: '>=0.3.2,<0.3.3.0a0'
     aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    aws-crt-cpp: '>=0.24.5,<0.24.6.0a0'
+    aws-crt-cpp: '>=0.24.7,<0.24.8.0a0'
     libcurl: '>=8.4.0,<9.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
     openssl: '>=3.1.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.182-h8df25a1_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.182-h8beafcf_7.conda
   hash:
-    md5: 18811e2cfea57f1ce72af7a60d9ad0f9
-    sha256: 9734287880abb46762d8a21d9ecd0d9db0de6f18d0951ec9c8dc9beb546c4778
+    md5: fe27868256b2d2a57d8136e08cdff2bb
+    sha256: c71ca50ad5e4c806d76b3584a53b295db317ffa92bd8f28eacc2bf88a3877eee
   category: main
   optional: false
 - name: magma
@@ -2410,10 +2395,10 @@ package:
     cudatoolkit: '>=11.8,<12'
     libmagma: '>=2.7.2,<2.7.3.0a0'
     libmagma_sparse: 2.7.2
-  url: https://conda.anaconda.org/conda-forge/linux-64/magma-2.7.2-h430c000_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/magma-2.7.2-h4aca40b_1.conda
   hash:
-    md5: 014daa0a5ef4ce10deb884d0d433bccf
-    sha256: 3489418f2b1e3ed54ebc0ff65ad0e3c941d321bbcc3410dc4e7b0bf5d05afeb7
+    md5: 8b99104c73b4ce6ed48b42b97c4801f7
+    sha256: 11ce651051ed0c2229f6ed052d8ecc29454f861be73c7e0dd55b1d1edd04f5c8
   category: main
   optional: false
 - name: tokenizers
@@ -2438,7 +2423,7 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    aws-crt-cpp: '>=0.24.5,<0.24.6.0a0'
+    aws-crt-cpp: '>=0.24.7,<0.24.8.0a0'
     aws-sdk-cpp: '>=1.11.182,<1.11.183.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     glog: '>=0.6.0,<0.7.0a0'
@@ -2452,14 +2437,14 @@ package:
     libutf8proc: '>=2.8.0,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=1.9.0,<1.9.1.0a0'
+    orc: '>=1.9.2,<1.9.3.0a0'
     re2: ''
     snappy: '>=1.1.10,<2.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.1-h0406937_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.1-h2b6da2a_4_cpu.conda
   hash:
-    md5: 6cd542d836507e0c9bec0c0d6112b024
-    sha256: 461384bb5fba971abc5d43a986222d73ae72e15034e7b403e0ba94c5712db887
+    md5: 764b78f1b4fba866bba4135f327d1ceb
+    sha256: 4dd49028b0db6e2867c35057b0bd86b512a91c204db89dcf2cb673d284622c12
   category: main
   optional: false
 - name: pytorch
@@ -2550,10 +2535,10 @@ package:
     libarrow: 14.0.1
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.1-h59595ed_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.1-h59595ed_4_cpu.conda
   hash:
-    md5: dc5eb5026d43d5a9cebd03b335f190c8
-    sha256: 9d8e19f90f463ca85254d8e16181d65fa1c01b7a4833cbb72ed911a509dd9f12
+    md5: 497560810ac6fe37df1e2d0a890a2c69
+    sha256: 132fbc4e57dc67d1a61f3da54afe10f4f9566d255cf538fb8f7e3ea2d51e299d
   category: main
   optional: false
 - name: libarrow-flight
@@ -2564,14 +2549,14 @@ package:
     libabseil: '>=20230802.1,<20230803.0a0'
     libarrow: 14.0.1
     libgcc-ng: '>=12'
-    libgrpc: '>=1.59.2,<1.60.0a0'
+    libgrpc: '>=1.59.3,<1.60.0a0'
     libprotobuf: '>=4.24.4,<4.24.5.0a0'
     libstdcxx-ng: '>=12'
     ucx: '>=1.15.0,<1.16.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.1-h120cb0d_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.1-h120cb0d_4_cpu.conda
   hash:
-    md5: cf189c716cd96362c7c91d6d9fda6b0b
-    sha256: 7df11fe1fc0a6b8ca633c718fec92aa28a2bbe07f74d114b1bd2cd267439311c
+    md5: abdfe485e0d186160782a854891c5ae1
+    sha256: bd7c4e517732faf3d7a5b4194b179fc209cd24934a9cc7800e2b6cc479d0d6cc
   category: main
   optional: false
 - name: libarrow-gandiva
@@ -2587,10 +2572,10 @@ package:
     libutf8proc: '>=2.8.0,<3.0a0'
     openssl: '>=3.1.4,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.1-hacb8726_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.1-hacb8726_4_cpu.conda
   hash:
-    md5: 05d9955c98398a0978eca62e526fc0ee
-    sha256: 984435cf158cecf05ee9dcbaf47e0825aa4a7ae32809c7d6bf0d1d1654f2236f
+    md5: 0a08043413f6fd8d03ad503413ac66e1
+    sha256: d55c724695789a139500fc16a83cac6985458b5e049f92df243f9882170031db
   category: main
   optional: false
 - name: libparquet
@@ -2603,10 +2588,10 @@ package:
     libstdcxx-ng: '>=12'
     libthrift: '>=0.19.0,<0.19.1.0a0'
     openssl: '>=3.1.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.1-h352af49_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.1-h352af49_4_cpu.conda
   hash:
-    md5: 5b5c9968e5872bc65a3f69a38c389003
-    sha256: 9d3e94b10d0cf5c71420a8f22ffd9f58189bc52a937296798b9c3bb5b5c75809
+    md5: 0dda61f1eb2dc47d807c1f5ec3ad0cdc
+    sha256: 812cc59632beb00006e32434e1c2e1fc6cff51647549c54edf8e0243e6086c03
   category: main
   optional: false
 - name: libarrow-dataset
@@ -2619,10 +2604,10 @@ package:
     libgcc-ng: '>=12'
     libparquet: 14.0.1
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.1-h59595ed_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.1-h59595ed_4_cpu.conda
   hash:
-    md5: b7948e05ad29fb89dfe18f23f445bc86
-    sha256: 9b246befad12c156dd10b7e91d32a4515abee2fc8c5e2b408d6bc1c2ea73edb0
+    md5: 1a4c89f8a071976813de665b3fba5a04
+    sha256: 8d2bb27800eb8ccc6818eee0a6320ba2c0c8899c8cc1757026bca694069a7d45
   category: main
   optional: false
 - name: libarrow-flight-sql
@@ -2635,10 +2620,10 @@ package:
     libgcc-ng: '>=12'
     libprotobuf: '>=4.24.4,<4.24.5.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.1-h61ff412_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.1-h61ff412_4_cpu.conda
   hash:
-    md5: fa7db8ca53a9eb0ca62893209d4a52d6
-    sha256: b34f3e189572c8009b22e3920229eb8cf6e37897d632e2729a966236b5bc9746
+    md5: 69468e4ea6ab681fd218b0abc2084cbb
+    sha256: a0ad5c7613132e6903fc929c001466785e88d4ae1c0b04e49605f1366eb4dbae
   category: main
   optional: false
 - name: libarrow-substrait
@@ -2652,10 +2637,10 @@ package:
     libgcc-ng: '>=12'
     libprotobuf: '>=4.24.4,<4.24.5.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.1-h61ff412_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.1-h61ff412_4_cpu.conda
   hash:
-    md5: 279bf5749bd65e468b2b564d29ca95c0
-    sha256: 427889bb5091aaba58b3cd5d5ffbcc5936811af3084fa8a16bc885ecfee137d0
+    md5: 44127a40001dba3cc6fbdfcd5331bc51
+    sha256: d1af57d44adfb51f354bdd65a7a8f93595c57fd3a1e5b8b9285f6315a122acc5
   category: main
   optional: false
 - name: pyarrow
@@ -2676,10 +2661,10 @@ package:
     numpy: '>=1.23.5,<2.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.1-py311h39c9aba_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.1-py311h39c9aba_4_cpu.conda
   hash:
-    md5: ee5e344d03f1fe29c52f7cc55a755ac0
-    sha256: 1846ed170dca8ad173a5e461760d0455832caa4fa630e28b98fd3c1d0360c70b
+    md5: 95f7ef34dbc15c5d714fdb0f02ff0d00
+    sha256: d3c24ac39ed0b21a2c15a3b6cfa9b24148b0eaf5d6c69dd93a1260ce0d7795fe
   category: main
   optional: false
 - name: datasets
@@ -2709,7 +2694,7 @@ package:
   category: main
   optional: false
 - name: transformers
-  version: 4.34.0
+  version: 4.35.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -2728,10 +2713,10 @@ package:
     safetensors: '>=0.3.1'
     tokenizers: '>=0.14,<0.15'
     tqdm: '>=4.27'
-  url: https://conda.anaconda.org/conda-forge/noarch/transformers-4.34.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/transformers-4.35.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 03b3e27e66a08258392785b3205c6d60
-    sha256: 9d10765e948c0b451d701e62ba2474cffe6ce7964088cc87b1b342c00d6fba27
+    md5: d00f8b25d116ff7c5be94e7b3cf5c3d6
+    sha256: 3836d0d338ce6a713b069270deaba44e352f587f09c02015aaa62e3f2ee375b6
   category: main
   optional: false
 - name: optimum

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -13,7 +13,7 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: 34917454cc3b52bed3e7b3da235c906f4609f0f3887b9a16690d8989475bce2b
+    linux-64: dc3b8acd2e43b67d9f0f4e899e2cf5c9236c5f8ba0d3f13afd0664baaa029b81
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -37,260 +37,6 @@ package:
     sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   category: main
   optional: false
-- name: ca-certificates
-  version: 2023.11.17
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.11.17-hbcca054_0.conda
-  hash:
-    md5: 01ffc8d36f9eba0ce0b3c1955fa780ee
-    sha256: fb4b9f4b7d885002db0b93e22f44b5b03791ef3d4efdc9d0662185a0faafd6b6
-  category: main
-  optional: false
-- name: cuda-cudart
-  version: 11.8.89
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-11.8.89-0.tar.bz2
-  hash:
-    md5: b68c7ef3eda01e95d5903fb508c5e440
-    sha256: f8cf96ae45acf1bef5ff0be3e849d87e3543144ec8c0075db235f4933113a3b0
-  category: main
-  optional: false
-- name: cuda-cupti
-  version: 11.8.87
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cupti-11.8.87-0.tar.bz2
-  hash:
-    md5: 2f4b4933285400137cf029fef9a7daa6
-    sha256: 38bdbaf93504da170945b9e1db4d28e2e053c5a93baa7d7e3f09ca94ad6948bb
-  category: main
-  optional: false
-- name: cuda-nvrtc
-  version: 11.8.89
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-11.8.89-0.tar.bz2
-  hash:
-    md5: f4af75ee32661708c979630cdb8f4987
-    sha256: 8ed6b83df491ab3bee78ee561c3361854d36ec01ef944a9578332774e9c21611
-  category: main
-  optional: false
-- name: cuda-nvtx
-  version: 11.8.86
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvtx-11.8.86-0.tar.bz2
-  hash:
-    md5: 1825ffc3feb608f2752073935e90bb49
-    sha256: 50cb4a4c91cf7eb8a8771c3dca7dda2e1d55be9d65d249b4303120f0437f8605
-  category: main
-  optional: false
-- name: cuda-version
-  version: '11.8'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/cuda-version-11.8-h70ddcb2_2.conda
-  hash:
-    md5: 601900ec9ff06f62f76a247148e52c04
-    sha256: cb8a81465d5fa1b27e14981b7e1a9be4fc90945261a7459427e7bfb42129e26c
-  category: main
-  optional: false
-- name: ld_impl_linux-64
-  version: '2.40'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
-  hash:
-    md5: 7aca3059a1729aa76c597603f10b0dd3
-    sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
-  category: main
-  optional: false
-- name: libcublas
-  version: 11.11.3.6
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/nvidia/linux-64/libcublas-11.11.3.6-0.tar.bz2
-  hash:
-    md5: 7700a48c99151d2b77e7838aa0852da9
-    sha256: c03d5d7ee8b279808f8bd11ccbb5b6ced263f56dcb87e9268cb590a705729b6f
-  category: main
-  optional: false
-- name: libcufft
-  version: 10.9.0.58
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/nvidia/linux-64/libcufft-10.9.0.58-0.tar.bz2
-  hash:
-    md5: dbb21687334ce5f8e6a233cb18ee406b
-    sha256: 3d9d93773d69b5826cd61c93333da45f7efd3a3aa09164effc9562eb7039cc8b
-  category: main
-  optional: false
-- name: libcufile
-  version: 1.8.1.2
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/nvidia/linux-64/libcufile-1.8.1.2-0.tar.bz2
-  hash:
-    md5: 9216c3ab5eb551bb7c2c4f604b4e7614
-    sha256: f399e21e2d8a286d74354c0df94635f259cfb6649031a8f48a5654f97387014f
-  category: main
-  optional: false
-- name: libcurand
-  version: 10.3.4.101
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/nvidia/linux-64/libcurand-10.3.4.101-0.tar.bz2
-  hash:
-    md5: c19aee1cc95a33b3aadc62113f1e57f2
-    sha256: 0c001fd158a81b5fff10cd711805f87c8d11a9f5794ea9fa5aa76aef129c0b48
-  category: main
-  optional: false
-- name: libcusolver
-  version: 11.4.1.48
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/nvidia/linux-64/libcusolver-11.4.1.48-0.tar.bz2
-  hash:
-    md5: a497123295be4e0bd221da5bf215f8b8
-    sha256: d04ae207677639c79ef2f9e90f92186e61b82ccc26632bac87ddc9e607ac3173
-  category: main
-  optional: false
-- name: libcusparse
-  version: 11.7.5.86
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/nvidia/linux-64/libcusparse-11.7.5.86-0.tar.bz2
-  hash:
-    md5: 853c37fabd07b5b91d3007afc82c3ed4
-    sha256: 61f9bee3a0ed675a8978815071b63a6bbfe3ea141c2d12613ba1d1cc65c584d2
-  category: main
-  optional: false
-- name: libnpp
-  version: 11.8.0.86
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/nvidia/linux-64/libnpp-11.8.0.86-0.tar.bz2
-  hash:
-    md5: 03822c4b5dae5988ba9dcb7eae837345
-    sha256: 086cf6c07bad0b0856400b8ba7e53f525f1fdb0a5d9ab635a11509d676c933cb
-  category: main
-  optional: false
-- name: libnvjpeg
-  version: 11.9.0.86
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/nvidia/linux-64/libnvjpeg-11.9.0.86-0.tar.bz2
-  hash:
-    md5: e42d6f0f20feb0cba0165d5cae33362f
-    sha256: edc9f27315dd85a97490b9af3943ce2a2d3eb7e13fc287a37c33cf78853f6421
-  category: main
-  optional: false
-- name: libstdcxx-ng
-  version: 13.2.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_3.conda
-  hash:
-    md5: 937eaed008f6bf2191c5fe76f87755e9
-    sha256: 6c6c49efedcc5709a66f19fb6b26b69c6a5245310fd1d9a901fd5e38aaf7f882
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.11'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
-  hash:
-    md5: d786502c97404c94d7d58d258a445a65
-    sha256: 0be3ac1bf852d64f553220c7e6457e9c047dfb7412da9d22fbaa67e60858b3cf
-  category: main
-  optional: false
-- name: tzdata
-  version: 2023c
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
-  hash:
-    md5: 939e3e74d8be4dac89ce83b20de2492a
-    sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  category: main
-  optional: false
-- name: cuda-libraries
-  version: 11.8.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cuda-cudart: '>=11.8.89'
-    cuda-nvrtc: '>=11.8.89'
-    libcublas: '>=11.11.3.6'
-    libcufft: '>=10.9.0.58'
-    libcufile: '>=1.4.0.31'
-    libcurand: '>=10.3.0.86'
-    libcusolver: '>=11.4.1.48'
-    libcusparse: '>=11.7.5.86'
-    libnpp: '>=11.8.0.86'
-    libnvjpeg: '>=11.9.0.86'
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-libraries-11.8.0-0.tar.bz2
-  hash:
-    md5: 3a43d100104e52ac8209a834c82ab231
-    sha256: c49445809212502739d41f2a5613dfaba32e0e39d45ffa5b154528d5b3a004cd
-  category: main
-  optional: false
-- name: cuda-runtime
-  version: 11.8.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cuda-libraries: '>=11.8.0'
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-runtime-11.8.0-0.tar.bz2
-  hash:
-    md5: 3ca379d762f8d7bd727df9e2c9b30664
-    sha256: 4ec90f237174c33514a898a363eb9e65edd93df0b571362ac0bda590d7d4ba29
-  category: main
-  optional: false
-- name: pytorch-cuda
-  version: '11.8'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cuda-cudart: '>=11.8,<12.0'
-    cuda-cupti: '>=11.8,<12.0'
-    cuda-libraries: '>=11.8,<12.0'
-    cuda-nvrtc: '>=11.8,<12.0'
-    cuda-nvtx: '>=11.8,<12.0'
-    cuda-runtime: '>=11.8,<12.0'
-    libcublas: '>=11.11.3.6,<12.0.1.189'
-    libcufft: '>=10.9.0.58,<11.0.0.21'
-    libcusolver: '>=11.4.1.48,<11.4.2.57'
-    libcusparse: '>=11.7.5.86,<12.0.0.76'
-    libnpp: '>=11.8.0.86,<12.0.0.30'
-    libnvjpeg: '>=11.9.0.86,<12.0.0.28'
-  url: https://conda.anaconda.org/pytorch/linux-64/pytorch-cuda-11.8-h7e8668a_5.tar.bz2
-  hash:
-    md5: 48e990086eb245cce92f09b45a34651e
-    sha256: 81a9df218f84b45386818dbc180180a5adb7a5df097d1c4c7ec05c5fa5b0f8ca
-  category: main
-  optional: false
 - name: _openmp_mutex
   version: '4.5'
   manager: conda
@@ -304,29 +50,350 @@ package:
     sha256: 84a66275da3a66e3f3e70e9d8f10496d807d01a9e4ec16cd2274cc5e28c478fc
   category: main
   optional: false
-- name: libgcc-ng
-  version: 13.2.0
+- name: accelerate
+  version: 0.24.1
   manager: conda
   platform: linux-64
   dependencies:
-    _libgcc_mutex: '0.1'
-    _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_3.conda
+    numpy: '>=1.17'
+    packaging: '>=20.0'
+    psutil: ''
+    python: '>=3.8.0'
+    pytorch: '>=1.10.0'
+    pyyaml: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/accelerate-0.24.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 23fdf1fef05baeb7eadc2aed5fb0011f
-    sha256: 5e88f658e07a30ab41b154b42c59f079b168acfa9551a75bdc972099453f4105
+    md5: f145fda3d83dd29c8cdb5966bea45c56
+    sha256: a897315648a9eeafaff6ca43d928c93801abbee2c3542ec17934a21ff055c1a4
+  category: main
+  optional: false
+- name: aiohttp
+  version: 3.9.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aiosignal: '>=1.1.2'
+    async-timeout: '>=4.0,<5.0'
+    attrs: '>=17.3.0'
+    frozenlist: '>=1.1.1'
+    libgcc-ng: '>=12'
+    multidict: '>=4.5,<7.0'
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+    yarl: '>=1.0,<2.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.9.1-py310h2372a71_0.conda
+  hash:
+    md5: f367877549376e985a3df1dc430692ae
+    sha256: 6a3983f2ee81308ae0716790ae780f63915f47fcd6a1038d3c75a78fcb675f23
+  category: main
+  optional: false
+- name: aiosignal
+  version: 1.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    frozenlist: '>=1.1.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: d1e1eb7e21a9e2c74279d87dafb68156
+    sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
+  category: main
+  optional: false
+- name: annotated-types
+  version: 0.6.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    typing-extensions: '>=4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.6.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 997c29372bdbe2afee073dff71f35923
+    sha256: 3a2c98154d95cfd54daba6b7d507d31f5ba07ac2ad955c44eb041b66563193cd
+  category: main
+  optional: false
+- name: async-timeout
+  version: 4.0.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    typing-extensions: '>=3.6.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3ce482ec3066e6d809dbbb1d1679f215
+    sha256: bd8b698e7f037a9c6107216646f1191f4f7a7fc6da6c34d1a6d4c211bcca8979
+  category: main
+  optional: false
+- name: attrs
+  version: 23.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+  hash:
+    md5: 3edfead7cedd1ab4400a6c588f3e75f8
+    sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
+  category: main
+  optional: false
+- name: aws-c-auth
+  version: 0.7.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
+    aws-c-common: '>=0.9.10,<0.9.11.0a0'
+    aws-c-http: '>=0.7.14,<0.7.15.0a0'
+    aws-c-io: '>=0.13.36,<0.13.37.0a0'
+    aws-c-sdkutils: '>=0.1.12,<0.1.13.0a0'
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.8-h5c941e0_1.conda
+  hash:
+    md5: 65d47e98af07d5e361707dda2ce44f3a
+    sha256: 48c768d96b09396190b717e126d33ca68f3d2786a068af188fd16fa469cbad76
+  category: main
+  optional: false
+- name: aws-c-cal
+  version: 0.6.9
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-common: '>=0.9.10,<0.9.11.0a0'
+    libgcc-ng: '>=12'
+    openssl: '>=3.2.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.9-h5d48c4d_2.conda
+  hash:
+    md5: 9e51dfd5da37c1817d2a850188861987
+    sha256: ec56734a24eee51e2f89bec3d686dd2c4dbb09d0305248b1d14e4c748065dc23
   category: main
   optional: false
 - name: aws-c-common
-  version: 0.9.8
+  version: 0.9.10
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.8-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.10-hd590300_0.conda
   hash:
-    md5: 1fd5f2ae093f2dbf28dc4f18fca57309
-    sha256: 09075cb426a0b903b7ca86e4f399eb0be02b6d24e403792a5f378064fcb7a08b
+    md5: 93729f7a54b25cb135ac2b67ea3a7603
+    sha256: dba8a20acedc6bc3574e4068c196969881462ad831aae267d25fbc9409785a6b
+  category: main
+  optional: false
+- name: aws-c-compression
+  version: 0.2.17
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-common: '>=0.9.10,<0.9.11.0a0'
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h7f92143_7.conda
+  hash:
+    md5: c55a1a0c1419fcdfce6d21c41b0f92ab
+    sha256: ce508018c1109d4e5c6b65695639deaa2beea31edc39145bb810efb13ffed2c3
+  category: main
+  optional: false
+- name: aws-c-event-stream
+  version: 0.3.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-common: '>=0.9.10,<0.9.11.0a0'
+    aws-c-io: '>=0.13.36,<0.13.37.0a0'
+    aws-checksums: '>=0.1.17,<0.1.18.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.3.2-h0bcb0bb_8.conda
+  hash:
+    md5: 21dafb60b5854f82b196f32e5857dec6
+    sha256: d2855cd791a95648ac773aa6561c61f9e77450f123c8aa82eea1d66e90d5bfb1
+  category: main
+  optional: false
+- name: aws-c-http
+  version: 0.7.14
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
+    aws-c-common: '>=0.9.10,<0.9.11.0a0'
+    aws-c-compression: '>=0.2.17,<0.2.18.0a0'
+    aws-c-io: '>=0.13.36,<0.13.37.0a0'
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.7.14-hd268abd_3.conda
+  hash:
+    md5: 0b0f7174a0f94d2c9a02fb24f6fc0d00
+    sha256: ff7e6252a299a59b7e6494723ef3043ba31643ec2a750b8593037bc757a2c4fa
+  category: main
+  optional: false
+- name: aws-c-io
+  version: 0.13.36
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
+    aws-c-common: '>=0.9.10,<0.9.11.0a0'
+    libgcc-ng: '>=12'
+    s2n: '>=1.3.56,<1.3.57.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.36-he14a76f_1.conda
+  hash:
+    md5: d15f4dfeef1d65de9a5283c984981776
+    sha256: ca5094093d0f2de9b0b2bd4697088565d0ef930364df8a67c8b79172dc9c209d
+  category: main
+  optional: false
+- name: aws-c-mqtt
+  version: 0.9.10
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-common: '>=0.9.10,<0.9.11.0a0'
+    aws-c-http: '>=0.7.14,<0.7.15.0a0'
+    aws-c-io: '>=0.13.36,<0.13.37.0a0'
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.9.10-h35285c7_2.conda
+  hash:
+    md5: 0cca0a3d7dc82f219ac46635478952f6
+    sha256: 246276b22393302b4e9acb934ec40bb78d3be74e7bd2c110272b46c5370a60ee
+  category: main
+  optional: false
+- name: aws-c-s3
+  version: 0.4.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-auth: '>=0.7.8,<0.7.9.0a0'
+    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
+    aws-c-common: '>=0.9.10,<0.9.11.0a0'
+    aws-c-http: '>=0.7.14,<0.7.15.0a0'
+    aws-c-io: '>=0.13.36,<0.13.37.0a0'
+    aws-checksums: '>=0.1.17,<0.1.18.0a0'
+    libgcc-ng: '>=12'
+    openssl: '>=3.2.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.4.3-h0448019_0.conda
+  hash:
+    md5: d193ad6b5c2d47c679202afe5b69b371
+    sha256: d99862ce623c68dd86225520c08bfe5ff46a0af885530a3faca4d3d54c7480bf
+  category: main
+  optional: false
+- name: aws-c-sdkutils
+  version: 0.1.12
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-common: '>=0.9.10,<0.9.11.0a0'
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.12-h7f92143_6.conda
+  hash:
+    md5: fe9b3bb0a3961dfb12506d865d818c00
+    sha256: 8f3b8f8b7b1f021eac80018d03ff24e2b390627b53eb17f07476f38ea67f4c56
+  category: main
+  optional: false
+- name: aws-checksums
+  version: 0.1.17
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-common: '>=0.9.10,<0.9.11.0a0'
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-h7f92143_6.conda
+  hash:
+    md5: 46bd4e9c2fd10de83bae22f0bb71139b
+    sha256: ac2082211e7d5fd3036f9abd7e398ef67d5327efb3808f17a30fcab59acacbfb
+  category: main
+  optional: false
+- name: aws-crt-cpp
+  version: 0.24.9
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-auth: '>=0.7.8,<0.7.9.0a0'
+    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
+    aws-c-common: '>=0.9.10,<0.9.11.0a0'
+    aws-c-event-stream: '>=0.3.2,<0.3.3.0a0'
+    aws-c-http: '>=0.7.14,<0.7.15.0a0'
+    aws-c-io: '>=0.13.36,<0.13.37.0a0'
+    aws-c-mqtt: '>=0.9.10,<0.9.11.0a0'
+    aws-c-s3: '>=0.4.3,<0.4.4.0a0'
+    aws-c-sdkutils: '>=0.1.12,<0.1.13.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.24.9-h4a91382_1.conda
+  hash:
+    md5: 24fd53c945b2548249fb84ed0b892d7e
+    sha256: 3c13e38acd391c2a4f1bc8242f8ef535d1ef6f3bc6233caf6b01c0861f8bcb94
+  category: main
+  optional: false
+- name: aws-sdk-cpp
+  version: 1.11.210
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-common: '>=0.9.10,<0.9.11.0a0'
+    aws-c-event-stream: '>=0.3.2,<0.3.3.0a0'
+    aws-checksums: '>=0.1.17,<0.1.18.0a0'
+    aws-crt-cpp: '>=0.24.9,<0.24.10.0a0'
+    libcurl: '>=8.4.0,<9.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.210-h6d06844_3.conda
+  hash:
+    md5: 286c286f196adb854dcf7e482f84867f
+    sha256: 445493080bcd97df8638bf54e7bfe4f3149b08b5567079ef4b3a000f657a3204
+  category: main
+  optional: false
+- name: blas
+  version: '2.120'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    _openmp_mutex: '>=4.5'
+    blas-devel: 3.9.0
+    libblas: 3.9.0
+    libcblas: 3.9.0
+    libgcc-ng: '>=12'
+    libgfortran-ng: ''
+    libgfortran5: '>=12.3.0'
+    liblapack: 3.9.0
+    liblapacke: 3.9.0
+    llvm-openmp: '>=17.0.5'
+  url: https://conda.anaconda.org/conda-forge/linux-64/blas-2.120-mkl.conda
+  hash:
+    md5: 9444330235a4828878cbe9c897ba0aa3
+    sha256: e2310fc7086d0af41c62e0d84f04591bf4c3b974ae80754c3650f37f07c667ab
+  category: main
+  optional: false
+- name: blas-devel
+  version: 3.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libblas: 3.9.0
+    libcblas: 3.9.0
+    liblapack: 3.9.0
+    liblapacke: 3.9.0
+    mkl: '>=2023.2.0,<2024.0a0'
+    mkl-devel: 2023.2.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/blas-devel-3.9.0-20_linux64_mkl.conda
+  hash:
+    md5: 079d50df2338a3d47522d7e84c3dfbf6
+    sha256: 74a99c20b857a01c0e1bdb00c2aec4696cf895451278d9e24171b3eed7ba1d68
+  category: main
+  optional: false
+- name: brotli-python
+  version: 1.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py310hc6cd4ac_1.conda
+  hash:
+    md5: 1f95722c94f00b69af69a066c7433714
+    sha256: e22268d81905338570786921b3def88e55f9ed6d0ccdd17d9fbae31a02fbef69
   category: main
   optional: false
 - name: bzip2
@@ -342,956 +409,26 @@ package:
   category: main
   optional: false
 - name: c-ares
-  version: 1.22.1
+  version: 1.23.0
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.22.1-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.23.0-hd590300_0.conda
   hash:
-    md5: 8430bd266c7b2cfbda403f7585d5ee86
-    sha256: d41cf87938ba66de538b91afed3ece9b4cf5ed082a7d1c1add46b70f482f34b9
+    md5: d459949bc10f64dee1595c176c2e6291
+    sha256: 6b0eee827bade11c2964a05867499a50ad2a9d1b14dfe18fb867a3bc9357f56f
   category: main
   optional: false
-- name: cudatoolkit
-  version: 11.8.0
+- name: ca-certificates
+  version: 2023.11.17
   manager: conda
   platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cudatoolkit-11.8.0-h4ba93d1_12.conda
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.11.17-hbcca054_0.conda
   hash:
-    md5: 59a4d915d3406b3d11298e927db71ae0
-    sha256: fec3919316eef16368c2ab013c77beaf3f40b2f6a2f2bd5227bbd4ab7fa8dd8c
-  category: main
-  optional: false
-- name: gflags
-  version: 2.2.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=7.5.0'
-    libstdcxx-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
-  hash:
-    md5: cddaf2c63ea4a5901cf09524c490ecdc
-    sha256: a853c0cacf53cfc59e1bca8d6e5cdfe9f38fce836f08c2a69e35429c2a492e77
-  category: main
-  optional: false
-- name: gmp
-  version: 6.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_0.conda
-  hash:
-    md5: 0e33ef437202db431aa5a928248cf2e8
-    sha256: 2a50495b6bbbacb03107ea0b752d8358d4a40b572d124a8cade068c147f344f5
-  category: main
-  optional: false
-- name: icu
-  version: '73.2'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
-  hash:
-    md5: cc47e1facc155f91abd89b11e48e72ff
-    sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
-  category: main
-  optional: false
-- name: keyutils
-  version: 1.6.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=10.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
-  hash:
-    md5: 30186d27e2c9fa62b45fb1476b7200e3
-    sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
-  category: main
-  optional: false
-- name: libabseil
-  version: '20230802.1'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
-  hash:
-    md5: 2785ddf4cb0e7e743477991d64353947
-    sha256: 8729021a93e67bb93b4e73ef0a132499db516accfea11561b667635bcd0507e7
-  category: main
-  optional: false
-- name: libaio
-  version: 0.3.113
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=10.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libaio-0.3.113-h166bdaf_0.tar.bz2
-  hash:
-    md5: 06656768fe0cb08ee3ccc231a1aaf365
-    sha256: 0d667dff725e8187bef78a8cffc7e0427c2a8125a90bafe196fa444e5c68bde9
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
-  hash:
-    md5: aec6c91c7371c26392a06708a73c70e5
-    sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
-  category: main
-  optional: false
-- name: libcrc32c
-  version: 1.1.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.4.0'
-    libstdcxx-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
-  hash:
-    md5: c965a5aa0d5c1c37ffc62dff36e28400
-    sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
-  hash:
-    md5: 6f8720dff19e17ce5d48cfe7f3d2f0a3
-    sha256: 8c9635aa0ea28922877dc96358f9547f6a55fc7e2eb75a556b05f1725496baf9
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
-  hash:
-    md5: 6305a3dd2752c76335295da4e581f2fd
-    sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
-  category: main
-  optional: false
-- name: libffi
-  version: 3.4.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
-  hash:
-    md5: d645c6d2ac96843a2bfaccd2d62b3ac3
-    sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
-  category: main
-  optional: false
-- name: libgfortran5
-  version: 13.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=13.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_3.conda
-  hash:
-    md5: c714d905cdfa0e70200f68b80cc04764
-    sha256: 0084a1d29a4f8ee3b8edad80eb6c42e5f0480f054f28cf713fb314bebb347a50
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.17'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=10.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
-  hash:
-    md5: b62b52da46c39ee2bc3c162ac7f1804d
-    sha256: 6a81ebac9f1aacdf2b4f945c87ad62b972f0f69c8e0981d68e111739e6720fd7
-  category: main
-  optional: false
-- name: libnsl
-  version: 2.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
-  hash:
-    md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
-    sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
-  category: main
-  optional: false
-- name: libnuma
-  version: 2.0.16
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.16-h0b41bf4_1.conda
-  hash:
-    md5: 28bfe2cb11357ccc5be21101a6b7ce86
-    sha256: 814a50cba215548ec3ebfb53033ffb9b3b070b2966570ff44910b8d9ba1c359d
-  category: main
-  optional: false
-- name: libutf8proc
-  version: 2.8.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
-  hash:
-    md5: ede4266dc02e875fe1ea77b25dd43747
-    sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
-  category: main
-  optional: false
-- name: libuuid
-  version: 2.38.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
-  hash:
-    md5: 40b61aab5c7ba9ff276c41cfffe6b80b
-    sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
-  category: main
-  optional: false
-- name: libuv
-  version: 1.46.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.46.0-hd590300_0.conda
-  hash:
-    md5: d23c76f7e6dcd6243d1b6ef5e62d17d2
-    sha256: 4bc4c946e9a532c066442714eeeeb1ffbd03cd89789c4047293f5e782b5fedd7
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.2.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
-  hash:
-    md5: f36c115f1ee199da648e0597ec2047ad
-    sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
-  category: main
-  optional: false
-- name: lz4-c
-  version: 1.9.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
-  hash:
-    md5: 318b08df404f9c9be5712aaa5a6f0bb0
-    sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
-  category: main
-  optional: false
-- name: nccl
-  version: 2.19.4.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cuda-version: '>=11.8,<12.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nccl-2.19.4.1-h6103f9b_0.conda
-  hash:
-    md5: 2946f0e841f1f0be90c90bc67877d417
-    sha256: bb8ae7c3004065f44798aaf75f5b25e5b6262437c6581d0814f60c0960e62359
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.4'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
-  hash:
-    md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
-    sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
-  category: main
-  optional: false
-- name: openssl
-  version: 3.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    ca-certificates: ''
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.0-hd590300_0.conda
-  hash:
-    md5: 68223671a2b68cdf7241eb4679ab2dd4
-    sha256: a8ca7c31be33894bd70bb34786d1a8c26ae650382411250b61f6b5249b69a23e
-  category: main
-  optional: false
-- name: rdma-core
-  version: '28.9'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-28.9-h59595ed_1.conda
-  hash:
-    md5: aeffb7c06b5f65e55e6c637408dc4100
-    sha256: 832f9393ab3144ce6468c6f150db9d398fad4451e96a8879afb3059f0c9902f6
-  category: main
-  optional: false
-- name: sleef
-  version: 3.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    _openmp_mutex: '>=4.5'
-    libgcc-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.5.1-h9b69904_2.tar.bz2
-  hash:
-    md5: 6e016cf4c525d04a7bd038cee53ad3fd
-    sha256: 77d644a16f682e6d01df63fe9d25315011393498b63cf08c0e548780e46b2170
-  category: main
-  optional: false
-- name: snappy
-  version: 1.1.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
-  hash:
-    md5: e6d228cd0bb74a51dd18f5bfce0b4115
-    sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
-  category: main
-  optional: false
-- name: xxhash
-  version: 0.8.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xxhash-0.8.2-hd590300_0.conda
-  hash:
-    md5: f08fb5c89edfc4aadee1c81d4cfb1fa1
-    sha256: 6fe74a8fd84ab0dc25e4dc3e0c22388dd8accb212897a208b14fe5d4fbb8fc2f
-  category: main
-  optional: false
-- name: xz
-  version: 5.2.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
-  hash:
-    md5: 2161070d867d1b1204ea749c8eec4ef0
-    sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
-  category: main
-  optional: false
-- name: yaml
-  version: 0.2.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
-  hash:
-    md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
-    sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
-  category: main
-  optional: false
-- name: aws-c-cal
-  version: 0.6.9
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.8,<0.9.9.0a0'
-    libgcc-ng: '>=12'
-    openssl: '>=3.1.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.9-h3b91eb8_1.conda
-  hash:
-    md5: ab28ae62aa4738f7ca0622554aadc31b
-    sha256: 8bca41960971a2f6eea0d61a30e6d8b1bf80f520b5959aba92b87d1385d3d0cd
-  category: main
-  optional: false
-- name: aws-c-compression
-  version: 0.2.17
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.8,<0.9.9.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-hfd9eb17_6.conda
-  hash:
-    md5: aee687dcfcc2a75d77b6e6024273978a
-    sha256: d67e50aff37474eee393346d71c9e4bbb6d190f86722ac932b2837acfea33f76
-  category: main
-  optional: false
-- name: aws-c-sdkutils
-  version: 0.1.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.8,<0.9.9.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.12-hfd9eb17_5.conda
-  hash:
-    md5: af2bccdb4cf6e9254969426fd53c7c65
-    sha256: d109677012abbf7e062d2a64c0df55523b056e74e5895650841b49f7f94a48a1
-  category: main
-  optional: false
-- name: aws-checksums
-  version: 0.1.17
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.8,<0.9.9.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-hfd9eb17_5.conda
-  hash:
-    md5: 92077b8c5f72e9b81f069b1eb492ab80
-    sha256: fa197cea5d34038066ac743ffa3ae688c057152fff55226ec740c5f68a136282
-  category: main
-  optional: false
-- name: cudnn
-  version: 8.8.0.121
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cuda-version: '>=11.0,<12.0a0'
-    cudatoolkit: 11.*
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cudnn-8.8.0.121-h838ba91_4.conda
-  hash:
-    md5: a465de35ca7a3b05f43bf7267e8e8ebb
-    sha256: f3fe3a6e0d6de423cadd6de644680f71d97b18becef225bcb9aa4f570e623a1e
-  category: main
-  optional: false
-- name: glog
-  version: 0.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gflags: '>=2.2.2,<2.3.0a0'
-    libgcc-ng: '>=10.3.0'
-    libstdcxx-ng: '>=10.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
-  hash:
-    md5: b31f3565cb84435407594e548a2fb7b2
-    sha256: 888cbcfb67f6e3d88a4c4ab9d26c9a406f620c4101a35dc6d2dbadb95f2221d4
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libbrotlicommon: 1.1.0
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
-  hash:
-    md5: f07002e225d7a60a694d42a7bf5ff53f
-    sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libbrotlicommon: 1.1.0
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
-  hash:
-    md5: 5fc11c6020d421960607d821310fcd4d
-    sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
-  category: main
-  optional: false
-- name: libedit
-  version: 3.1.20191231
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=7.5.0'
-    ncurses: '>=6.2,<7.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
-  hash:
-    md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
-    sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
-  category: main
-  optional: false
-- name: libevent
-  version: 2.1.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    openssl: '>=3.1.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
-  hash:
-    md5: a1cfcc585f0c42bf8d5546bb1dfb668d
-    sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
-  category: main
-  optional: false
-- name: libgfortran-ng
-  version: 13.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgfortran5: 13.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_3.conda
-  hash:
-    md5: 73031c79546ad06f1fe62e57fdd021bc
-    sha256: 5b918950b84605b6865de438757f507b1eff73c96fd562f7022c80028b088c14
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.58.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    c-ares: '>=1.21.0,<2.0a0'
-    libev: '>=4.33,<4.34.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_0.conda
-  hash:
-    md5: 9b13d5ee90fc9f09d54fd403247342b4
-    sha256: 151b18e4f92dcca263a6d23e4beb0c4e2287aa1c7d0587ff71ef50035ed34aca
-  category: main
-  optional: false
-- name: libprotobuf
-  version: 4.24.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.24.4-hf27288f_0.conda
-  hash:
-    md5: 1a0287ab734591ad63603734f923016b
-    sha256: 3e0f6454190abb27edd2aeb724688ee440de133edb02cbb17d5609ba36aa8be0
-  category: main
-  optional: false
-- name: libre2-11
-  version: 2023.06.02
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.06.02-h7a70373_0.conda
-  hash:
-    md5: c0e7eacd9694db3ef5ef2979a7deea70
-    sha256: 22b0b2169c80b65665ba0d6418bd5d3d4c7d89915ee0f9613403efe871c27db8
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.44.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.2-h2797004_0.conda
-  hash:
-    md5: 3b6a9f225c3dbe0d24f4fedd4625c5bf
-    sha256: ee2c4d724a3ed60d5b458864d66122fb84c6ce1df62f735f90d8db17b66cd88a
-  category: main
-  optional: false
-- name: libssh2
-  version: 1.11.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
-  hash:
-    md5: 1f5a58e686b13bcfde88b93f547d23fe
-    sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.11.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    icu: '>=73.2,<74.0a0'
-    libgcc-ng: '>=12'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.6-h232c23b_0.conda
-  hash:
-    md5: 427a3e59d66cb5d145020bd9c6493334
-    sha256: e6183d5e57ee48cc1fc4340477c31a6bd8be4d3ba5dded82cbca0d5280591086
-  category: main
-  optional: false
-- name: mpfr
-  version: 4.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gmp: '>=6.2.1,<7.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.1-h9458935_0.conda
-  hash:
-    md5: 4c28f3210b30250037a4a627eeee9e0f
-    sha256: 008230a53ff15cf61966476b44f7ba2c779826825b9ca639a0a2b44d8f7aa6cb
-  category: main
-  optional: false
-- name: readline
-  version: '8.2'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    ncurses: '>=6.3,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
-  hash:
-    md5: 47d31b792659ce70f470b5c82fdfb7a4
-    sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
-  category: main
-  optional: false
-- name: s2n
-  version: 1.3.56
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    openssl: '>=3.1.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.3.56-h06160fa_0.conda
-  hash:
-    md5: 04b4845b9e9b5a0ee6eba013ecdbbddb
-    sha256: 4c00411d49fefc6a53167c3120e386b3f35510544a44d2e647615b510a622f29
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
-  hash:
-    md5: d453b98d9c83e71da0741bb0ff4d76bc
-    sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
-  category: main
-  optional: false
-- name: ucx
-  version: 1.15.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libnuma: '>=2.0.16,<3.0a0'
-    libstdcxx-ng: '>=12'
-    rdma-core: '>=28.9,<29.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-h64cca9d_0.conda
-  hash:
-    md5: b35b1f1a9fdbf93266c91f297dc9060e
-    sha256: 8a4dce10304fee0df715addec3d078421aa7aa0824422a6630d621d15bd98e5f
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
-  hash:
-    md5: 04b88013080254850d6c01ed54810589
-    sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
-  category: main
-  optional: false
-- name: aws-c-io
-  version: 0.13.36
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.8,<0.9.9.0a0'
-    libgcc-ng: '>=12'
-    s2n: '>=1.3.56,<1.3.57.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.36-hc23c90e_0.conda
-  hash:
-    md5: 57259ec9cdbba3e4897e950dd976c93d
-    sha256: b3fe3214b11f3cf3c631bef0be09f88610103c0262225a368914ce149533900d
-  category: main
-  optional: false
-- name: krb5
-  version: 1.21.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    keyutils: '>=1.6.1,<2.0a0'
-    libedit: '>=3.1.20191231,<4.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.1.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
-  hash:
-    md5: cd95826dbd331ed1be26bdf401432844
-    sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
-  category: main
-  optional: false
-- name: libhwloc
-  version: 2.9.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.11.5,<2.12.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.9.3-default_h554bfaf_1009.conda
-  hash:
-    md5: f36ddc11ca46958197a45effdd286e45
-    sha256: 6950fee24766d03406e0f6f965262a5d98829c71eed8d1004f313892423b559b
-  category: main
-  optional: false
-- name: libllvm15
-  version: 15.0.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.11.4,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-h5cf9203_3.conda
-  hash:
-    md5: 9efe82d44b76a7529a1d702e5a37752e
-    sha256: bb94e7535a309c2a8d58585cb82bac954ed59f473eef2cac6ea677d6f576a3b6
-  category: main
-  optional: false
-- name: libopenblas
-  version: 0.3.25
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.25-pthreads_h413a1c8_0.conda
-  hash:
-    md5: d172b34a443b95f86089e8229ddc9a17
-    sha256: 628564517895ee1b09cf72c817548bd80ef1acce6a8214a8520d9f7b44c4cfaf
-  category: main
-  optional: false
-- name: libsentencepiece
-  version: 0.1.99
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libgcc-ng: '>=12'
-    libprotobuf: '>=4.24.4,<4.24.5.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsentencepiece-0.1.99-h866249d_5.conda
-  hash:
-    md5: 9085779608d2f81d39ebd26144cd8b6d
-    sha256: 0066690b5670f45abd3a2ec8dd6c4f2629b0a666c3b4293e460d1bb391e325f5
-  category: main
-  optional: false
-- name: libthrift
-  version: 0.19.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libevent: '>=2.1.12,<2.1.13.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
-  hash:
-    md5: 8cdb7d41faa0260875ba92414c487e2d
-    sha256: 719add2cf20d144ef9962c57cd0f77178259bdb3aae1cded2e2b2b7c646092f5
-  category: main
-  optional: false
-- name: llvm-openmp
-  version: 17.0.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-17.0.5-h4dfa4b3_0.conda
-  hash:
-    md5: 799291c22ec87a0c86c0a4fc0e22b1c5
-    sha256: ef97ef1a8cbdb7862bc5a6f2aee17e289e355cb6f26a0f3b0549aedc9c174853
-  category: main
-  optional: false
-- name: mpc
-  version: 1.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gmp: '>=6.2.1,<7.0a0'
-    libgcc-ng: '>=12'
-    mpfr: '>=4.1.0,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.3.1-hfe3b2da_0.conda
-  hash:
-    md5: 289c71e83dc0daa7d4c81f04180778ca
-    sha256: 2f88965949ba7b4b21e7e5facd62285f7c6efdb17359d1b365c3bb4ecc968d29
-  category: main
-  optional: false
-- name: orc
-  version: 1.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libprotobuf: '>=4.24.4,<4.24.5.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.1.10,<2.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.2-h4b38347_0.conda
-  hash:
-    md5: 6e6f990b097d3e237e18a8e321d08484
-    sha256: a06dd76bc0f2f99f5db5e348298c906007c3aa9e31b963f71d16e63f770b900b
-  category: main
-  optional: false
-- name: python
-  version: 3.11.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    ld_impl_linux-64: '>=2.36.1'
-    libexpat: '>=2.5.0,<3.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libgcc-ng: '>=12'
-    libnsl: '>=2.0.0,<2.1.0a0'
-    libsqlite: '>=3.43.0,<4.0a0'
-    libuuid: '>=2.38.1,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.6-hab00c5b_0_cpython.conda
-  hash:
-    md5: b0dfbe2fcbfdb097d321bfd50ecddab1
-    sha256: 84f13bd70cff5dcdaee19263b2d4291d5793856a718efc1b63a9cfa9eb6e2ca1
-  category: main
-  optional: false
-- name: re2
-  version: 2023.06.02
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libre2-11: 2023.06.02
-  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.06.02-h2873b5e_0.conda
-  hash:
-    md5: bb2d5e593ef13fe4aff0bc9440f945ae
-    sha256: 3e0bfb04b6d43312d711c5b49dbc3c7660b2e6e681ed504b1b322794462a1bcd
-  category: main
-  optional: false
-- name: attrs
-  version: 23.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
-  hash:
-    md5: 3edfead7cedd1ab4400a6c588f3e75f8
-    sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
-  category: main
-  optional: false
-- name: aws-c-event-stream
-  version: 0.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.8,<0.9.9.0a0'
-    aws-c-io: '>=0.13.36,<0.13.37.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.3.2-h1fff966_7.conda
-  hash:
-    md5: 7badad50132f03325f1060dc0a006465
-    sha256: abade13c6c6b480bc68ba11d2616f81951207ce44115ac10d237c38251641380
-  category: main
-  optional: false
-- name: aws-c-http
-  version: 0.7.14
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.8,<0.9.9.0a0'
-    aws-c-compression: '>=0.2.17,<0.2.18.0a0'
-    aws-c-io: '>=0.13.36,<0.13.37.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.7.14-hc86c171_2.conda
-  hash:
-    md5: e092fb5c53b2915be20b19e8e31b016e
-    sha256: e29a5b81731995634338ced49d241c77f820df37977ab932a637351efc94adba
-  category: main
-  optional: false
-- name: brotli-python
-  version: 1.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hb755f60_1.conda
-  hash:
-    md5: cce9e7c3f1c307f2a5fb08a2922d6164
-    sha256: 559093679e9fdb6061b7b80ca0f9a31fe6ffc213f1dae65bc5c82e2cd1a94107
+    md5: 01ffc8d36f9eba0ce0b3c1955fa780ee
+    sha256: fb4b9f4b7d885002db0b93e22f44b5b03791ef3d4efdc9d0662185a0faafd6b6
   category: main
   optional: false
 - name: certifi
@@ -1343,6 +480,96 @@ package:
     sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
   category: main
   optional: false
+- name: coloredlogs
+  version: 15.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    humanfriendly: '>=9.1'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/coloredlogs-15.0.1-pyhd8ed1ab_3.tar.bz2
+  hash:
+    md5: 7b4fc18b7f66382257c45424eaf81935
+    sha256: 0bb37abbf3367add8a8e3522405efdbd06605acfc674488ef52486968f2c119d
+  category: main
+  optional: false
+- name: cuda-cudart
+  version: 11.8.89
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-11.8.89-0.tar.bz2
+  hash:
+    md5: b68c7ef3eda01e95d5903fb508c5e440
+    sha256: f8cf96ae45acf1bef5ff0be3e849d87e3543144ec8c0075db235f4933113a3b0
+  category: main
+  optional: false
+- name: cuda-cupti
+  version: 11.8.87
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cupti-11.8.87-0.tar.bz2
+  hash:
+    md5: 2f4b4933285400137cf029fef9a7daa6
+    sha256: 38bdbaf93504da170945b9e1db4d28e2e053c5a93baa7d7e3f09ca94ad6948bb
+  category: main
+  optional: false
+- name: cuda-libraries
+  version: 11.8.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cuda-cudart: '>=11.8.89'
+    cuda-nvrtc: '>=11.8.89'
+    libcublas: '>=11.11.3.6'
+    libcufft: '>=10.9.0.58'
+    libcufile: '>=1.4.0.31'
+    libcurand: '>=10.3.0.86'
+    libcusolver: '>=11.4.1.48'
+    libcusparse: '>=11.7.5.86'
+    libnpp: '>=11.8.0.86'
+    libnvjpeg: '>=11.9.0.86'
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-libraries-11.8.0-0.tar.bz2
+  hash:
+    md5: 3a43d100104e52ac8209a834c82ab231
+    sha256: c49445809212502739d41f2a5613dfaba32e0e39d45ffa5b154528d5b3a004cd
+  category: main
+  optional: false
+- name: cuda-nvrtc
+  version: 11.8.89
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-11.8.89-0.tar.bz2
+  hash:
+    md5: f4af75ee32661708c979630cdb8f4987
+    sha256: 8ed6b83df491ab3bee78ee561c3361854d36ec01ef944a9578332774e9c21611
+  category: main
+  optional: false
+- name: cuda-nvtx
+  version: 11.8.86
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvtx-11.8.86-0.tar.bz2
+  hash:
+    md5: 1825ffc3feb608f2752073935e90bb49
+    sha256: 50cb4a4c91cf7eb8a8771c3dca7dda2e1d55be9d65d249b4303120f0437f8605
+  category: main
+  optional: false
+- name: cuda-runtime
+  version: 11.8.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cuda-libraries: '>=11.8.0'
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-runtime-11.8.0-0.tar.bz2
+  hash:
+    md5: 3ca379d762f8d7bd727df9e2c9b30664
+    sha256: 4ec90f237174c33514a898a363eb9e65edd93df0b571362ac0bda590d7d4ba29
+  category: main
+  optional: false
 - name: dataclasses
   version: '0.8'
   manager: conda
@@ -1353,6 +580,57 @@ package:
   hash:
     md5: a362b2124b06aad102e2ee4581acee7d
     sha256: 63a83e62e0939bc1ab32de4ec736f6403084198c4639638b354a352113809c92
+  category: main
+  optional: false
+- name: datasets
+  version: 2.14.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aiohttp: ''
+    dill: '>=0.3.0,<0.3.8'
+    fsspec: '>=2023.1.0,<2023.9.0'
+    huggingface_hub: '>=0.14.0,<1.0.0'
+    importlib-metadata: ''
+    multiprocess: ''
+    numpy: '>=1.17'
+    packaging: ''
+    pandas: ''
+    pyarrow: '>=8.0.0'
+    python: '>=3.8.0'
+    python-xxhash: ''
+    pyyaml: '>=5.1'
+    requests: '>=2.19.0'
+    tqdm: '>=4.62.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.14.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3bec9fb1eeef5a6e316011f2a3543ffd
+    sha256: d3ecb2e0fbcec7fd6825cf032190eec6a0aa9c575498dcb71db96acedfb730d7
+  category: main
+  optional: false
+- name: deepspeed
+  version: 0.12.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    hjson-py: ''
+    libaio: '>=0.3.113,<0.4.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    numpy: ''
+    packaging: '>=20.0'
+    psutil: ''
+    py-cpuinfo: ''
+    pydantic: ''
+    pynvml: ''
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+    pytorch: ''
+    tqdm: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/deepspeed-0.12.2-cpu_py310h11dbdba_1.conda
+  hash:
+    md5: ba4505194815a5c166b2164ad067ecde
+    sha256: ff85b991c9ac42237c1ad9ea0ae818eb211c7fafdbf3ac003f0f17d43b1506b8
   category: main
   optional: false
 - name: dill
@@ -1397,12 +675,12 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.0-py311h459d7ec_1.conda
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.0-py310h2372a71_1.conda
   hash:
-    md5: 23d0b2d02252b32ee14e5063ccfb41e2
-    sha256: aa832b23e1cce4530fef50e87de95132ba29fb4731848b2c7d3d91f863d2b7f3
+    md5: c7b2865e86782925a872c8598b760c08
+    sha256: cd1e59ceac047d9f692bb7cc2a6a6e2356a7d3db660b076b4afb19d35db2fd02
   category: main
   optional: false
 - name: fsspec
@@ -1417,6 +695,46 @@ package:
     sha256: 0015e12d85b454ca8e09085e9e788a6156f4f1da1b270019cab2658381d60258
   category: main
   optional: false
+- name: gflags
+  version: 2.2.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=7.5.0'
+    libstdcxx-ng: '>=7.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
+  hash:
+    md5: cddaf2c63ea4a5901cf09524c490ecdc
+    sha256: a853c0cacf53cfc59e1bca8d6e5cdfe9f38fce836f08c2a69e35429c2a492e77
+  category: main
+  optional: false
+- name: glog
+  version: 0.6.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    gflags: '>=2.2.2,<2.3.0a0'
+    libgcc-ng: '>=10.3.0'
+    libstdcxx-ng: '>=10.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
+  hash:
+    md5: b31f3565cb84435407594e548a2fb7b2
+    sha256: 888cbcfb67f6e3d88a4c4ab9d26c9a406f620c4101a35dc6d2dbadb95f2221d4
+  category: main
+  optional: false
+- name: gmp
+  version: 6.3.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_0.conda
+  hash:
+    md5: 0e33ef437202db431aa5a928248cf2e8
+    sha256: 2a50495b6bbbacb03107ea0b752d8358d4a40b572d124a8cade068c147f344f5
+  category: main
+  optional: false
 - name: gmpy2
   version: 2.1.2
   manager: conda
@@ -1426,12 +744,12 @@ package:
     libgcc-ng: '>=12'
     mpc: '>=1.2.1,<2.0a0'
     mpfr: '>=4.1.0,<5.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.1.2-py311h6a5fa03_1.tar.bz2
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.1.2-py310h3ec546c_1.tar.bz2
   hash:
-    md5: 3515bd4a3d92bbd3cc2d25aac335e34d
-    sha256: 20862200f4d07ba583ab6ae9b56d7de2462474240872100973711dfa20d562d7
+    md5: 73f6fa50c32ddd985cf5fba7b890a75c
+    sha256: aeb52e14f33c17e11248bfe58383b935e101d86e89b5246373c590c7b127ab47
   category: main
   optional: false
 - name: hjson-py
@@ -1444,6 +762,26 @@ package:
   hash:
     md5: c30befad415322013e1e7418d7d23c56
     sha256: be791a584329f061d28940b2c76dcf92fbd63305e81ec8eaf91646d4e15db84b
+  category: main
+  optional: false
+- name: huggingface_hub
+  version: 0.16.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    filelock: ''
+    fsspec: ''
+    importlib-metadata: ''
+    packaging: '>=20.9'
+    python: '>=3.7.0'
+    pyyaml: '>=5.1'
+    requests: ''
+    tqdm: '>=4.42.1'
+    typing-extensions: '>=3.7.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.16.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1987745df86e9af7ff29d0352af8873a
+    sha256: bb5c10a9dff8213b74379c293d25abe4f887eadf2d20410286e3988fbf053b2b
   category: main
   optional: false
 - name: humanfriendly
@@ -1459,6 +797,19 @@ package:
     sha256: cd93d5d4b1d98f7ce76a8658c35de9c63e17b3a40e52f40fa2f459e0da83d0b1
   category: main
   optional: false
+- name: icu
+  version: '73.2'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+  hash:
+    md5: cc47e1facc155f91abd89b11e48e72ff
+    sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
+  category: main
+  optional: false
 - name: idna
   version: '3.6'
   manager: conda
@@ -1471,16 +822,367 @@ package:
     sha256: 6ee4c986d69ce61e60a20b2459b6f2027baeba153f0a64995fd3cb47c2cc7e07
   category: main
   optional: false
+- name: importlib-metadata
+  version: 6.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.8'
+    zipp: '>=0.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.9.0-pyha770c72_0.conda
+  hash:
+    md5: 9677d53e8eb8e3282e9d84c5d0c525d7
+    sha256: e43e6c2b76b76219268444907ab0797604be225fa1f3bfef1c666ec005fab07b
+  category: main
+  optional: false
+- name: importlib_metadata
+  version: 6.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    importlib-metadata: '>=6.9.0,<6.9.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.9.0-hd8ed1ab_0.conda
+  hash:
+    md5: a0c28e5b7f824a19bd8ee9255c9bd58c
+    sha256: 01633076b64cfd0a163f9665864449bce3fa0377f2b12a0bf0dacc5baaeec206
+  category: main
+  optional: false
+- name: jinja2
+  version: 3.1.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    markupsafe: '>=2.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+  hash:
+    md5: c8490ed5c70966d232fdd389d0dbed37
+    sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
+  category: main
+  optional: false
+- name: joblib
+  version: 1.3.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4da50d410f553db77e62ab62ffaa1abc
+    sha256: 31e05d47970d956206188480b038829d24ac11fe8216409d8584d93d40233878
+  category: main
+  optional: false
+- name: keyutils
+  version: 1.6.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=10.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  hash:
+    md5: 30186d27e2c9fa62b45fb1476b7200e3
+    sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  category: main
+  optional: false
+- name: krb5
+  version: 1.21.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    keyutils: '>=1.6.1,<2.0a0'
+    libedit: '>=3.1.20191231,<4.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    openssl: '>=3.1.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
+  hash:
+    md5: cd95826dbd331ed1be26bdf401432844
+    sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
+  category: main
+  optional: false
+- name: ld_impl_linux-64
+  version: '2.40'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+  hash:
+    md5: 7aca3059a1729aa76c597603f10b0dd3
+    sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
+  category: main
+  optional: false
+- name: libabseil
+  version: '20230802.1'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
+  hash:
+    md5: 2785ddf4cb0e7e743477991d64353947
+    sha256: 8729021a93e67bb93b4e73ef0a132499db516accfea11561b667635bcd0507e7
+  category: main
+  optional: false
+- name: libaio
+  version: 0.3.113
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=10.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libaio-0.3.113-h166bdaf_0.tar.bz2
+  hash:
+    md5: 06656768fe0cb08ee3ccc231a1aaf365
+    sha256: 0d667dff725e8187bef78a8cffc7e0427c2a8125a90bafe196fa444e5c68bde9
+  category: main
+  optional: false
+- name: libarrow
+  version: 14.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-crt-cpp: '>=0.24.9,<0.24.10.0a0'
+    aws-sdk-cpp: '>=1.11.210,<1.11.211.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    glog: '>=0.6.0,<0.7.0a0'
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libbrotlidec: '>=1.1.0,<1.2.0a0'
+    libbrotlienc: '>=1.1.0,<1.2.0a0'
+    libgcc-ng: '>=12'
+    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
+    libre2-11: '>=2023.6.2,<2024.0a0'
+    libstdcxx-ng: '>=12'
+    libutf8proc: '>=2.8.0,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    orc: '>=1.9.2,<1.9.3.0a0'
+    re2: ''
+    snappy: '>=1.1.10,<2.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.1-h422ced8_7_cpu.conda
+  hash:
+    md5: b223663b7d84c274f81b8df9b40e97d1
+    sha256: ec41d798314367d2722bbff5c2b5dae7cd6a9ec545c4b38c5685380ef8c3c74d
+  category: main
+  optional: false
+- name: libarrow-acero
+  version: 14.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libarrow: 14.0.1
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.1-h59595ed_7_cpu.conda
+  hash:
+    md5: 7a6f961134100e948769f32aa8a340f9
+    sha256: a51d7f31e375209f60e2943fbdc23439f24d65a92ea658a12cfe1dc559f2acde
+  category: main
+  optional: false
+- name: libarrow-dataset
+  version: 14.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libarrow: 14.0.1
+    libarrow-acero: 14.0.1
+    libgcc-ng: '>=12'
+    libparquet: 14.0.1
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.1-h59595ed_7_cpu.conda
+  hash:
+    md5: 609da65cd158689afbaf027fb2351c0d
+    sha256: 6bed779657093c001da835a06bd979e97101b6ff6ee907b17862eef9ad0791b5
+  category: main
+  optional: false
+- name: libarrow-flight
+  version: 14.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libarrow: 14.0.1
+    libgcc-ng: '>=12'
+    libgrpc: '>=1.59.3,<1.60.0a0'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    libstdcxx-ng: '>=12'
+    ucx: '>=1.15.0,<1.16.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.1-h120cb0d_7_cpu.conda
+  hash:
+    md5: fe72e2490bbfc0dc5f0b7425766d4e07
+    sha256: f7904df9f485869be26d226997f03d7ce95e50525d22bc1c3c4018391f0e93a6
+  category: main
+  optional: false
+- name: libarrow-flight-sql
+  version: 14.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libarrow: 14.0.1
+    libarrow-flight: 14.0.1
+    libgcc-ng: '>=12'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.1-h61ff412_7_cpu.conda
+  hash:
+    md5: 4672a569eb18e2ce9222a389817e25a8
+    sha256: 06a5331043c45603844433bf5c6c774a37ac43cb70186cece06c6446d93c233a
+  category: main
+  optional: false
+- name: libarrow-gandiva
+  version: 14.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libarrow: 14.0.1
+    libgcc-ng: '>=12'
+    libllvm15: '>=15.0.7,<15.1.0a0'
+    libre2-11: '>=2023.6.2,<2024.0a0'
+    libstdcxx-ng: '>=12'
+    libutf8proc: '>=2.8.0,<3.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+    re2: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.1-hacb8726_7_cpu.conda
+  hash:
+    md5: de205c2808a660a750bd6da31d2a577a
+    sha256: 6084474f6142861915bab408462ae73e26ae0f6506dd2adae4ce8ccb0f3e0b68
+  category: main
+  optional: false
+- name: libarrow-substrait
+  version: 14.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libarrow: 14.0.1
+    libarrow-acero: 14.0.1
+    libarrow-dataset: 14.0.1
+    libgcc-ng: '>=12'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.1-h61ff412_7_cpu.conda
+  hash:
+    md5: 990aa43c3de66af60163d652753f4c56
+    sha256: de0af53312b25f14641c22b132d54fbbb9b1a40ce1bef1c2a225255bd6521b62
+  category: main
+  optional: false
 - name: libblas
   version: 3.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    libopenblas: '>=0.3.25,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-20_linux64_openblas.conda
+    mkl: '>=2023.2.0,<2024.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-20_linux64_mkl.conda
   hash:
-    md5: 2b7bb4f7562c8cf334fc2e20c2d28abc
-    sha256: 8a0ee1de693a9b3da4a11b95ec81b40dd434bd01fa1f5f38f8268cd2146bf8f0
+    md5: 8bf521f6007b0b0eb91515a1165b5d85
+    sha256: 9e5f27fca79223a5d38ccdf4c468e798c3684ba01bdb6b4b44e61f2103a298eb
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
+  hash:
+    md5: aec6c91c7371c26392a06708a73c70e5
+    sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libbrotlicommon: 1.1.0
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
+  hash:
+    md5: f07002e225d7a60a694d42a7bf5ff53f
+    sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libbrotlicommon: 1.1.0
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
+  hash:
+    md5: 5fc11c6020d421960607d821310fcd4d
+    sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
+  category: main
+  optional: false
+- name: libcblas
+  version: 3.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libblas: 3.9.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-20_linux64_mkl.conda
+  hash:
+    md5: 7a2972758a03adc92d856072c71c9170
+    sha256: 841b4d44e20e5207f4a74ca98176629ead5ba590384ed6b0fe3c8600248c9fef
+  category: main
+  optional: false
+- name: libcrc32c
+  version: 1.1.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=9.4.0'
+    libstdcxx-ng: '>=9.4.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+  hash:
+    md5: c965a5aa0d5c1c37ffc62dff36e28400
+    sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
+  category: main
+  optional: false
+- name: libcublas
+  version: 11.11.3.6
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/nvidia/linux-64/libcublas-11.11.3.6-0.tar.bz2
+  hash:
+    md5: 7700a48c99151d2b77e7838aa0852da9
+    sha256: c03d5d7ee8b279808f8bd11ccbb5b6ced263f56dcb87e9268cb590a705729b6f
+  category: main
+  optional: false
+- name: libcufft
+  version: 10.9.0.58
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/nvidia/linux-64/libcufft-10.9.0.58-0.tar.bz2
+  hash:
+    md5: dbb21687334ce5f8e6a233cb18ee406b
+    sha256: 3d9d93773d69b5826cd61c93333da45f7efd3a3aa09164effc9562eb7039cc8b
+  category: main
+  optional: false
+- name: libcufile
+  version: 1.8.1.2
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/nvidia/linux-64/libcufile-1.8.1.2-0.tar.bz2
+  hash:
+    md5: 9216c3ab5eb551bb7c2c4f604b4e7614
+    sha256: f399e21e2d8a286d74354c0df94635f259cfb6649031a8f48a5654f97387014f
+  category: main
+  optional: false
+- name: libcurand
+  version: 10.3.4.101
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/nvidia/linux-64/libcurand-10.3.4.101-0.tar.bz2
+  hash:
+    md5: c19aee1cc95a33b3aadc62113f1e57f2
+    sha256: 0c001fd158a81b5fff10cd711805f87c8d11a9f5794ea9fa5aa76aef129c0b48
   category: main
   optional: false
 - name: libcurl
@@ -1499,6 +1201,134 @@ package:
   hash:
     md5: 1158ac1d2613b28685644931f11ee807
     sha256: 25f4b6a8827d7b17a66e0bd9b5d194bf9a9e4a46fb14e2ef472fdad4b39426a6
+  category: main
+  optional: false
+- name: libcusolver
+  version: 11.4.1.48
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/nvidia/linux-64/libcusolver-11.4.1.48-0.tar.bz2
+  hash:
+    md5: a497123295be4e0bd221da5bf215f8b8
+    sha256: d04ae207677639c79ef2f9e90f92186e61b82ccc26632bac87ddc9e607ac3173
+  category: main
+  optional: false
+- name: libcusparse
+  version: 11.7.5.86
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/nvidia/linux-64/libcusparse-11.7.5.86-0.tar.bz2
+  hash:
+    md5: 853c37fabd07b5b91d3007afc82c3ed4
+    sha256: 61f9bee3a0ed675a8978815071b63a6bbfe3ea141c2d12613ba1d1cc65c584d2
+  category: main
+  optional: false
+- name: libedit
+  version: 3.1.20191231
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=7.5.0'
+    ncurses: '>=6.2,<7.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  hash:
+    md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+    sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=7.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
+  hash:
+    md5: 6f8720dff19e17ce5d48cfe7f3d2f0a3
+    sha256: 8c9635aa0ea28922877dc96358f9547f6a55fc7e2eb75a556b05f1725496baf9
+  category: main
+  optional: false
+- name: libevent
+  version: 2.1.12
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    openssl: '>=3.1.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  hash:
+    md5: a1cfcc585f0c42bf8d5546bb1dfb668d
+    sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
+  category: main
+  optional: false
+- name: libffi
+  version: 3.4.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=9.4.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  hash:
+    md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+    sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  category: main
+  optional: false
+- name: libgcc-ng
+  version: 13.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    _libgcc_mutex: '0.1'
+    _openmp_mutex: '>=4.5'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_3.conda
+  hash:
+    md5: 23fdf1fef05baeb7eadc2aed5fb0011f
+    sha256: 5e88f658e07a30ab41b154b42c59f079b168acfa9551a75bdc972099453f4105
+  category: main
+  optional: false
+- name: libgfortran-ng
+  version: 13.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgfortran5: 13.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_3.conda
+  hash:
+    md5: 73031c79546ad06f1fe62e57fdd021bc
+    sha256: 5b918950b84605b6865de438757f507b1eff73c96fd562f7022c80028b088c14
+  category: main
+  optional: false
+- name: libgfortran5
+  version: 13.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=13.2.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_3.conda
+  hash:
+    md5: c714d905cdfa0e70200f68b80cc04764
+    sha256: 0084a1d29a4f8ee3b8edad80eb6c42e5f0480f054f28cf713fb314bebb347a50
+  category: main
+  optional: false
+- name: libgoogle-cloud
+  version: 2.12.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libcrc32c: '>=1.1.2,<1.2.0a0'
+    libcurl: '>=8.4.0,<9.0a0'
+    libgcc-ng: '>=12'
+    libgrpc: '>=1.59.2,<1.60.0a0'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    libstdcxx-ng: '>=12'
+    openssl: '>=3.1.4,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-h5206363_4.conda
+  hash:
+    md5: b5eb63d2683102be45d17c55021282f6
+    sha256: 82a7d211d0df165b073f9e8ba6d789c4b1c7c4882d546ca12d40f201fc3496fc
   category: main
   optional: false
 - name: libgrpc
@@ -1521,18 +1351,406 @@ package:
     sha256: 3f95a2792e565b628cb284de92017a37a1cddc4a3f83453b8f75d9adc9f8cfdd
   category: main
   optional: false
+- name: libhwloc
+  version: 2.9.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libxml2: '>=2.11.5,<2.12.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.9.3-default_h554bfaf_1009.conda
+  hash:
+    md5: f36ddc11ca46958197a45effdd286e45
+    sha256: 6950fee24766d03406e0f6f965262a5d98829c71eed8d1004f313892423b559b
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.17'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=10.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
+  hash:
+    md5: b62b52da46c39ee2bc3c162ac7f1804d
+    sha256: 6a81ebac9f1aacdf2b4f945c87ad62b972f0f69c8e0981d68e111739e6720fd7
+  category: main
+  optional: false
+- name: liblapack
+  version: 3.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libblas: 3.9.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-20_linux64_mkl.conda
+  hash:
+    md5: 4db0cd03efcdab535f6f066aca4cddbb
+    sha256: 21b4324dd65815f6b5a83c15f0b9a201434d0aa55eeecc37efce7ee70bbbf482
+  category: main
+  optional: false
+- name: liblapacke
+  version: 3.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libblas: 3.9.0
+    libcblas: 3.9.0
+    liblapack: 3.9.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-20_linux64_mkl.conda
+  hash:
+    md5: 3dea5e9be386b963d7f4368966e238b3
+    sha256: 0e6ece3ff4b2088d30b5836771e87440840c643be0ab885a2605be002d566a34
+  category: main
+  optional: false
+- name: libllvm15
+  version: 15.0.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libxml2: '>=2.11.4,<2.12.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    zstd: '>=1.5.2,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-h5cf9203_3.conda
+  hash:
+    md5: 9efe82d44b76a7529a1d702e5a37752e
+    sha256: bb94e7535a309c2a8d58585cb82bac954ed59f473eef2cac6ea677d6f576a3b6
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.58.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    c-ares: '>=1.21.0,<2.0a0'
+    libev: '>=4.33,<4.34.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.4,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_0.conda
+  hash:
+    md5: 9b13d5ee90fc9f09d54fd403247342b4
+    sha256: 151b18e4f92dcca263a6d23e4beb0c4e2287aa1c7d0587ff71ef50035ed34aca
+  category: main
+  optional: false
+- name: libnpp
+  version: 11.8.0.86
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/nvidia/linux-64/libnpp-11.8.0.86-0.tar.bz2
+  hash:
+    md5: 03822c4b5dae5988ba9dcb7eae837345
+    sha256: 086cf6c07bad0b0856400b8ba7e53f525f1fdb0a5d9ab635a11509d676c933cb
+  category: main
+  optional: false
+- name: libnsl
+  version: 2.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  hash:
+    md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+    sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  category: main
+  optional: false
+- name: libnuma
+  version: 2.0.16
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.16-h0b41bf4_1.conda
+  hash:
+    md5: 28bfe2cb11357ccc5be21101a6b7ce86
+    sha256: 814a50cba215548ec3ebfb53033ffb9b3b070b2966570ff44910b8d9ba1c359d
+  category: main
+  optional: false
+- name: libnvjpeg
+  version: 11.9.0.86
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/nvidia/linux-64/libnvjpeg-11.9.0.86-0.tar.bz2
+  hash:
+    md5: e42d6f0f20feb0cba0165d5cae33362f
+    sha256: edc9f27315dd85a97490b9af3943ce2a2d3eb7e13fc287a37c33cf78853f6421
+  category: main
+  optional: false
+- name: libparquet
+  version: 14.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libarrow: 14.0.1
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libthrift: '>=0.19.0,<0.19.1.0a0'
+    openssl: '>=3.2.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.1-h352af49_7_cpu.conda
+  hash:
+    md5: 9de3444d12b70908260836960a4c7e86
+    sha256: cff499bca81e420afe5cfcaa048fd1478e7ff2d49763036dfa7af181885cb199
+  category: main
+  optional: false
+- name: libprotobuf
+  version: 4.24.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.24.4-hf27288f_0.conda
+  hash:
+    md5: 1a0287ab734591ad63603734f923016b
+    sha256: 3e0f6454190abb27edd2aeb724688ee440de133edb02cbb17d5609ba36aa8be0
+  category: main
+  optional: false
+- name: libre2-11
+  version: 2023.06.02
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.06.02-h7a70373_0.conda
+  hash:
+    md5: c0e7eacd9694db3ef5ef2979a7deea70
+    sha256: 22b0b2169c80b65665ba0d6418bd5d3d4c7d89915ee0f9613403efe871c27db8
+  category: main
+  optional: false
+- name: libsentencepiece
+  version: 0.1.99
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libgcc-ng: '>=12'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsentencepiece-0.1.99-h866249d_5.conda
+  hash:
+    md5: 9085779608d2f81d39ebd26144cd8b6d
+    sha256: 0066690b5670f45abd3a2ec8dd6c4f2629b0a666c3b4293e460d1bb391e325f5
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.44.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.2-h2797004_0.conda
+  hash:
+    md5: 3b6a9f225c3dbe0d24f4fedd4625c5bf
+    sha256: ee2c4d724a3ed60d5b458864d66122fb84c6ce1df62f735f90d8db17b66cd88a
+  category: main
+  optional: false
+- name: libssh2
+  version: 1.11.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+  hash:
+    md5: 1f5a58e686b13bcfde88b93f547d23fe
+    sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
+  category: main
+  optional: false
+- name: libstdcxx-ng
+  version: 13.2.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_3.conda
+  hash:
+    md5: 937eaed008f6bf2191c5fe76f87755e9
+    sha256: 6c6c49efedcc5709a66f19fb6b26b69c6a5245310fd1d9a901fd5e38aaf7f882
+  category: main
+  optional: false
+- name: libthrift
+  version: 0.19.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libevent: '>=2.1.12,<2.1.13.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.3,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
+  hash:
+    md5: 8cdb7d41faa0260875ba92414c487e2d
+    sha256: 719add2cf20d144ef9962c57cd0f77178259bdb3aae1cded2e2b2b7c646092f5
+  category: main
+  optional: false
+- name: libutf8proc
+  version: 2.8.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+  hash:
+    md5: ede4266dc02e875fe1ea77b25dd43747
+    sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
+  category: main
+  optional: false
+- name: libuuid
+  version: 2.38.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  hash:
+    md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+    sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.11.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    icu: '>=73.2,<74.0a0'
+    libgcc-ng: '>=12'
+    libiconv: '>=1.17,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    xz: '>=5.2.6,<6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.6-h232c23b_0.conda
+  hash:
+    md5: 427a3e59d66cb5d145020bd9c6493334
+    sha256: e6183d5e57ee48cc1fc4340477c31a6bd8be4d3ba5dded82cbca0d5280591086
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.2.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+  hash:
+    md5: f36c115f1ee199da648e0597ec2047ad
+    sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
+  category: main
+  optional: false
+- name: llvm-openmp
+  version: 17.0.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-17.0.6-h4dfa4b3_0.conda
+  hash:
+    md5: c1665f9c1c9f6c93d8b4e492a6a39056
+    sha256: 18a9db4cc139e72e8eac80a34f6536491fe318d3785bc2c35fac42cd00676376
+  category: main
+  optional: false
+- name: lz4-c
+  version: 1.9.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+  hash:
+    md5: 318b08df404f9c9be5712aaa5a6f0bb0
+    sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
+  category: main
+  optional: false
 - name: markupsafe
   version: 2.1.3
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py311h459d7ec_1.conda
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py310h2372a71_1.conda
   hash:
-    md5: 71120b5155a0c500826cf81536721a15
-    sha256: e1a9930f35e39bf65bc293e24160b83ebf9f800f02749f65358e1c04882ee6b0
+    md5: b74e07a054c479e45a83a83fc5be713c
+    sha256: ac46cc2f6d4bbeedcd2f508e43f43143a9286ced55730d8d97a3c91ceceb0d56
+  category: main
+  optional: false
+- name: mkl
+  version: 2023.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    _openmp_mutex: '>=4.5'
+    llvm-openmp: '>=17.0.3'
+    tbb: 2021.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-2023.2.0-h84fe81f_50496.conda
+  hash:
+    md5: 81d4a1a57d618adf0152db973d93b2ad
+    sha256: 046073737bf73153b0c39e343b197cdf0b7867d336962369407465a17ea5979a
+  category: main
+  optional: false
+- name: mkl-devel
+  version: 2023.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    mkl: 2023.2.0
+    mkl-include: 2023.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-devel-2023.2.0-ha770c72_50496.conda
+  hash:
+    md5: 3b4c50e31ff098b18a450e4f5f860adf
+    sha256: ddd54fd21d6ac8eec97674db20a8752a7eadd60c9778eb1443e075196813037a
+  category: main
+  optional: false
+- name: mkl-include
+  version: 2023.2.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-include-2023.2.0-h84fe81f_50496.conda
+  hash:
+    md5: 7af9fd0b2d7219f4a4200a34561340f6
+    sha256: da1720a3e065273e2456481b28abd64abc2396d221d87a02db5f14053be61a68
+  category: main
+  optional: false
+- name: mpc
+  version: 1.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    gmp: '>=6.2.1,<7.0a0'
+    libgcc-ng: '>=12'
+    mpfr: '>=4.1.0,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.3.1-hfe3b2da_0.conda
+  hash:
+    md5: 289c71e83dc0daa7d4c81f04180778ca
+    sha256: 2f88965949ba7b4b21e7e5facd62285f7c6efdb17359d1b365c3bb4ecc968d29
+  category: main
+  optional: false
+- name: mpfr
+  version: 4.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    gmp: '>=6.2.1,<7.0a0'
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.1-h9458935_0.conda
+  hash:
+    md5: 4c28f3210b30250037a4a627eeee9e0f
+    sha256: 008230a53ff15cf61966476b44f7ba2c779826825b9ca639a0a2b44d8f7aa6cb
   category: main
   optional: false
 - name: mpmath
@@ -1553,12 +1771,39 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.0.4-py311h459d7ec_1.conda
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.0.4-py310h2372a71_1.conda
   hash:
-    md5: 3dc76316237c8f7e7231d61b76c62b7c
-    sha256: 5bb152aab8fa22d68ce0c802a9990c406eb60a8041660071de0bd30a5cd5081c
+    md5: 7ca797f0a0c390ede770f415f5d5e039
+    sha256: d8180dcee801bcde6408d924bab0010fc956ae7a14681694af21f9d4382d8ee8
+  category: main
+  optional: false
+- name: multiprocess
+  version: 0.70.15
+  manager: conda
+  platform: linux-64
+  dependencies:
+    dill: '>=0.3.6'
+    libgcc-ng: '>=12'
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.15-py310h2372a71_1.conda
+  hash:
+    md5: 81644426a6bb61245ffadc49b5aa9a14
+    sha256: 2ba19287b111304701466b3dd3b0329f452be20e4aecf643a047b88ee3cde99a
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.4'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+  hash:
+    md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
+    sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
   category: main
   optional: false
 - name: networkx
@@ -1573,6 +1818,77 @@ package:
     sha256: 7629aa4f9f8cdff45ea7a4701fe58dccce5bf2faa01c26eb44cbb27b7e15ca9d
   category: main
   optional: false
+- name: numpy
+  version: 1.26.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libblas: '>=3.9.0,<4.0a0'
+    libcblas: '>=3.9.0,<4.0a0'
+    libgcc-ng: '>=12'
+    liblapack: '>=3.9.0,<4.0a0'
+    libstdcxx-ng: '>=12'
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.2-py310hb13e2d6_0.conda
+  hash:
+    md5: d3147cfbf72d6ae7bba10562208f6def
+    sha256: f5ea7769beb7827f4f5858d28bbdbc814c01649cb8cb81cccbba476ebe3798cd
+  category: main
+  optional: false
+- name: openssl
+  version: 3.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    ca-certificates: ''
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.0-hd590300_1.conda
+  hash:
+    md5: 603827b39ea2b835268adb8c821b8570
+    sha256: 80efc6f429bd8e622d999652e5cba2ca56fcdb9c16a439d2ce9b4313116e4a87
+  category: main
+  optional: false
+- name: optimum
+  version: 1.13.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    coloredlogs: ''
+    datasets: ''
+    huggingface_hub: '>=0.8.0'
+    numpy: ''
+    packaging: ''
+    protobuf: ''
+    python: '>=3.7'
+    pytorch: '>=1.9'
+    sentencepiece: '>=0.1.91'
+    sympy: ''
+    transformers: '>=4.26.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/optimum-1.13.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7bc29f1226e7e63bceed63fa46e09322
+    sha256: 4fa7a2cde0426cbc000aa1db96639d86122a172364aff262fecccfa0e2a57004
+  category: main
+  optional: false
+- name: orc
+  version: 1.9.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    snappy: '>=1.1.10,<2.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.2-h4b38347_0.conda
+  hash:
+    md5: 6e6f990b097d3e237e18a8e321d08484
+    sha256: a06dd76bc0f2f99f5db5e348298c906007c3aa9e31b963f71d16e63f770b900b
+  category: main
+  optional: false
 - name: packaging
   version: '23.2'
   manager: conda
@@ -1585,18 +1901,69 @@ package:
     sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
   category: main
   optional: false
+- name: pandas
+  version: 2.1.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    numpy: '>=1.22.4,<2.0a0'
+    python: '>=3.10,<3.11.0a0'
+    python-dateutil: '>=2.8.1'
+    python-tzdata: '>=2022a'
+    python_abi: 3.10.*
+    pytz: '>=2020.1'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.1.3-py310hcc13569_0.conda
+  hash:
+    md5: 30a39c1064e5efc578d83c2a5f7cd749
+    sha256: bb2b3e4a3f3d40b87ac214b88393a7f1ee5b2cac41d249c580d184f7edb30653
+  category: main
+  optional: false
+- name: pip
+  version: 23.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    setuptools: ''
+    wheel: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2400c0b86889f43aa52067161e1fb108
+    sha256: 435829a03e1c6009f013f29bb83de8b876c388820bf8cf69a7baeec25f6a3563
+  category: main
+  optional: false
+- name: protobuf
+  version: 4.24.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libabseil: '>=20230802.1,<20230803.0a0'
+    libgcc-ng: '>=12'
+    libprotobuf: '>=4.24.4,<4.24.5.0a0'
+    libstdcxx-ng: '>=12'
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.24.4-py310h620c231_0.conda
+  hash:
+    md5: 26b481407c457a2fde193b3717aa88d9
+    sha256: b6906d73b6e82b6f7f4d903d15a61ac21d84e00db088e0421db4cdbbe06fb490
+  category: main
+  optional: false
 - name: psutil
   version: 5.9.5
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py311h459d7ec_1.conda
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py310h2372a71_1.conda
   hash:
-    md5: 490d7fa8675afd1aa6f1b2332d156a45
-    sha256: e92d2120fc4b98fe838b3d52d4907fae97808bdd504fb84aa33aea8c4be7bc61
+    md5: cb25177acf28cc35cfa6c1ac1c679e22
+    sha256: db8a99bc41c1b0405c8e9daa92b9d4e7711f9717aff7fd3feeba407ca2a91aa2
   category: main
   optional: false
 - name: py-cpuinfo
@@ -1609,6 +1976,60 @@ package:
   hash:
     md5: 6f6d42b894118f8378fce11887ccdaff
     sha256: 1bb0459fdebf2f3155ee511e99097c5506ef206acbdd871b74ae9fc4b0c4a019
+  category: main
+  optional: false
+- name: pyarrow
+  version: 14.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libarrow: 14.0.1
+    libarrow-acero: 14.0.1
+    libarrow-dataset: 14.0.1
+    libarrow-flight: 14.0.1
+    libarrow-flight-sql: 14.0.1
+    libarrow-gandiva: 14.0.1
+    libarrow-substrait: 14.0.1
+    libgcc-ng: '>=12'
+    libparquet: 14.0.1
+    libstdcxx-ng: '>=12'
+    numpy: '>=1.22.4,<2.0a0'
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.1-py310hf9e7431_7_cpu.conda
+  hash:
+    md5: e719c295a31e24e447c0cfeac121abfe
+    sha256: c1933a2cec76e04e9c3e36b168f85571889ab30a3ecb183c381cc7e697b46efe
+  category: main
+  optional: false
+- name: pydantic
+  version: 2.5.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    annotated-types: '>=0.4.0'
+    pydantic-core: 2.14.5
+    python: '>=3.7'
+    typing-extensions: '>=4.6.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.5.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3f908ebfccbfd09946961862d26bb9af
+    sha256: e3baa6424af931d8d7c5a0554b24d85faf3471df8036181d598065beed3096de
+  category: main
+  optional: false
+- name: pydantic-core
+  version: 2.14.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+    typing-extensions: '>=4.6.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.14.5-py310hcb5633a_0.conda
+  hash:
+    md5: a47e1b53da51f577ee44e79f7589c388
+    sha256: 58ce2738657c5b3c5539465fa54eb499361df836034501c4bf03b1fc0ba9a1b7
   category: main
   optional: false
 - name: pynvml
@@ -1636,6 +2057,44 @@ package:
     sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
   category: main
   optional: false
+- name: python
+  version: 3.10.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    ld_impl_linux-64: '>=2.36.1'
+    libffi: '>=3.4,<4.0a0'
+    libgcc-ng: '>=12'
+    libnsl: '>=2.0.1,<2.1.0a0'
+    libsqlite: '>=3.43.2,<4.0a0'
+    libuuid: '>=2.38.1,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    ncurses: '>=6.4,<7.0a0'
+    openssl: '>=3.1.4,<4.0a0'
+    readline: '>=8.2,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+    xz: '>=5.2.6,<6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.13-hd12c33a_0_cpython.conda
+  hash:
+    md5: f3a8c32aa764c3e7188b4b810fc9d6ce
+    sha256: a53410f459f314537b379982717b1c5911efc2f0cc26d63c4d6f831bcb31c964
+  category: main
+  optional: false
+- name: python-dateutil
+  version: 2.8.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6'
+    six: '>=1.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: dd999d1cc9f79e67dbb855c8924c7984
+    sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
+  category: main
+  optional: false
 - name: python-tzdata
   version: '2023.3'
   manager: conda
@@ -1654,13 +2113,80 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
     xxhash: '>=0.8.2,<0.8.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-xxhash-3.4.1-py311h459d7ec_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-xxhash-3.4.1-py310h2372a71_0.conda
   hash:
-    md5: 60b5332b3989fda37884b92c7afd6a91
-    sha256: 91293b2ca0f36ac580f2be4b9c0858cdaec52eff95473841231dcd044acd2e12
+    md5: b631b889b0b4bc2fca7b8b977ca484b2
+    sha256: 9fb9e5d9a5c029ce00e0bcbedcaa1f415f84edc0db5bdf57beede000f3818991
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.10'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
+  hash:
+    md5: 26322ec5d7712c3ded99dd656142b8ce
+    sha256: 456bec815bfc2b364763084d08b412fdc4c17eb9ccc66a36cb775fa7ac3cbaec
+  category: main
+  optional: false
+- name: pytorch
+  version: 2.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    blas: '*'
+    filelock: ''
+    jinja2: ''
+    mkl: '>=2018'
+    networkx: ''
+    python: '>=3.10,<3.11.0a0'
+    pytorch-cuda: '>=11.8,<11.9'
+    pytorch-mutex: '1.0'
+    sympy: ''
+    torchtriton: 2.0.0
+    typing_extensions: ''
+  url: https://conda.anaconda.org/pytorch/linux-64/pytorch-2.0.1-py3.10_cuda11.8_cudnn8.7.0_0.tar.bz2
+  hash:
+    md5: e8dd4a234ce193267c4cbc981c042429
+    sha256: a4045451c624ce9f938a81398a20ff9e596ac89e27e29a3c1b7074da1ecbc3a5
+  category: main
+  optional: false
+- name: pytorch-cuda
+  version: '11.8'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cuda-cudart: '>=11.8,<12.0'
+    cuda-cupti: '>=11.8,<12.0'
+    cuda-libraries: '>=11.8,<12.0'
+    cuda-nvrtc: '>=11.8,<12.0'
+    cuda-nvtx: '>=11.8,<12.0'
+    cuda-runtime: '>=11.8,<12.0'
+    libcublas: '>=11.11.3.6,<12.0.1.189'
+    libcufft: '>=10.9.0.58,<11.0.0.21'
+    libcusolver: '>=11.4.1.48,<11.4.2.57'
+    libcusparse: '>=11.7.5.86,<12.0.0.76'
+    libnpp: '>=11.8.0.86,<12.0.0.30'
+    libnvjpeg: '>=11.9.0.86,<12.0.0.28'
+  url: https://conda.anaconda.org/pytorch/linux-64/pytorch-cuda-11.8-h7e8668a_5.tar.bz2
+  hash:
+    md5: 48e990086eb245cce92f09b45a34651e
+    sha256: 81a9df218f84b45386818dbc180180a5adb7a5df097d1c4c7ec05c5fa5b0f8ca
+  category: main
+  optional: false
+- name: pytorch-mutex
+  version: '1.0'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cuda.tar.bz2
+  hash:
+    md5: a948316e36fb5b11223b3fcfa93f8358
+    sha256: c16316183f51b74ca5eee4dcb8631052f328c0bbf244176734a0b7d390b81ee3
   category: main
   optional: false
 - name: pytz
@@ -1681,13 +2207,52 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
     yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py311h459d7ec_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py310h2372a71_1.conda
   hash:
-    md5: 52719a74ad130de8fb5d047dc91f247a
-    sha256: 28729ef1ffa7f6f9dfd54345a47c7faac5d34296d66a2b9891fb147f4efe1348
+    md5: bb010e368de4940771368bc3dc4c63e7
+    sha256: aa78ccddb0a75fa722f0f0eb3537c73ee1219c9dd46cea99d6b9eebfdd780f3d
+  category: main
+  optional: false
+- name: rdma-core
+  version: '49.0'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-49.0-hd3aeb46_1.conda
+  hash:
+    md5: 434d42b3ee35e1aaf6bb42d87730d1a4
+    sha256: dca608dd54c7782f15b6a99220fa1ac8f744c1e183ba69b5d0f29c5be85865b1
+  category: main
+  optional: false
+- name: re2
+  version: 2023.06.02
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libre2-11: 2023.06.02
+  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.06.02-h2873b5e_0.conda
+  hash:
+    md5: bb2d5e593ef13fe4aff0bc9440f945ae
+    sha256: 3e0bfb04b6d43312d711c5b49dbc3c7660b2e6e681ed504b1b322794462a1bcd
+  category: main
+  optional: false
+- name: readline
+  version: '8.2'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    ncurses: '>=6.3,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  hash:
+    md5: 47d31b792659ce70f470b5c82fdfb7a4
+    sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
   category: main
   optional: false
 - name: regex
@@ -1696,12 +2261,58 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/regex-2023.10.3-py311h459d7ec_0.conda
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/regex-2023.10.3-py310h2372a71_0.conda
   hash:
-    md5: c690bffc22c33b3a976d588937eb32bf
-    sha256: 80b761ea8ed126b3d12a0466ea925db6116527675f8eb8bd0f68b260f292e9e6
+    md5: 124bc31abd31cd6990a9f6ade3a4da2d
+    sha256: bf8e736b9b4f73c3142842b280982581037b40904b6dea4706ab137b3179c5c7
+  category: main
+  optional: false
+- name: requests
+  version: 2.31.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    certifi: '>=2017.4.17'
+    charset-normalizer: '>=2,<4'
+    idna: '>=2.5,<4'
+    python: '>=3.7'
+    urllib3: '>=1.21.1,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a30144e4156cdbb236f99ebb49828f8b
+    sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
+  category: main
+  optional: false
+- name: s2n
+  version: 1.3.56
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    openssl: '>=3.1.4,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.3.56-h06160fa_0.conda
+  hash:
+    md5: 04b4845b9e9b5a0ee6eba013ecdbbddb
+    sha256: 4c00411d49fefc6a53167c3120e386b3f35510544a44d2e647615b510a622f29
+  category: main
+  optional: false
+- name: sacremoses
+  version: 0.0.53
+  manager: conda
+  platform: linux-64
+  dependencies:
+    click: ''
+    joblib: ''
+    python: '>=3.6'
+    regex: ''
+    six: ''
+    tqdm: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/sacremoses-0.0.53-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 76c3c384fe0941f1b08193736e8e277a
+    sha256: 2fdc52c648c0a0d80f2f6f484cd0933f9b553d2e568bf8b63abe444974eb75b5
   category: main
   optional: false
 - name: safetensors
@@ -1710,12 +2321,27 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/safetensors-0.3.3-py311h46250e7_1.conda
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/safetensors-0.3.3-py310hcb5633a_1.conda
   hash:
-    md5: 1a1f04191eccfce868e8629e981aec6d
-    sha256: 02b16dea74388db9d1a58ad83c758d8dbd1b8c58c148ca247724baa3fad33962
+    md5: 7611b39e6ef1b8b073e73ce9e064377b
+    sha256: 94193b014a5ff85a81b50784f5c2d849bb0416ef19a98b7790b41bc27b2b19e3
+  category: main
+  optional: false
+- name: sentencepiece
+  version: 0.1.99
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libsentencepiece: 0.1.99
+    python_abi: 3.10.*
+    sentencepiece-python: 0.1.99
+    sentencepiece-spm: 0.1.99
+  url: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-0.1.99-hff52083_5.conda
+  hash:
+    md5: 91316164f742ec1ea419b57ca6e3e613
+    sha256: 6427acf2111b44f8a632f232b1148c41d288ea67da5dc5503613abf3914f930e
   category: main
   optional: false
 - name: sentencepiece-python
@@ -1727,12 +2353,12 @@ package:
     libprotobuf: '>=4.24.4,<4.24.5.0a0'
     libsentencepiece: 0.1.99
     libstdcxx-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-python-0.1.99-py311h4b01a32_5.conda
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-python-0.1.99-py310ha7b5816_5.conda
   hash:
-    md5: f5d4ec6558c3c0116436ebe2d5ceb0e9
-    sha256: edea39c669a4ff6d1c2c0d720fa1551d94c79eaa5e9061572dd31d7c2bfc237f
+    md5: 8c0b612a73313004b6e83f7af08712cb
+    sha256: 61227d21191add421a043fe67cf6d09d7b0c58ae58e04c1d2d1f6b3edb3f4b21
   category: main
   optional: false
 - name: sentencepiece-spm
@@ -1775,283 +2401,17 @@ package:
     sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
   category: main
   optional: false
-- name: tbb
-  version: 2021.10.0
+- name: snappy
+  version: 1.1.10
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libhwloc: '>=2.9.3,<2.9.4.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.10.0-h00ab1b0_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
   hash:
-    md5: eb0d5c122f42714f86a7058d1ce7b2e6
-    sha256: 79a6c48fa1df661af7ab3e4f5fa444dd305d87921be017413a8b97fd6d642328
-  category: main
-  optional: false
-- name: typing_extensions
-  version: 4.8.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
-  hash:
-    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
-    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
-  category: main
-  optional: false
-- name: wheel
-  version: 0.42.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1cdea58981c5cbc17b51973bcaddcea7
-    sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
-  category: main
-  optional: false
-- name: zipp
-  version: 3.17.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
-  category: main
-  optional: false
-- name: aiosignal
-  version: 1.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    frozenlist: '>=1.1.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: d1e1eb7e21a9e2c74279d87dafb68156
-    sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
-  category: main
-  optional: false
-- name: aws-c-auth
-  version: 0.7.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.8,<0.9.9.0a0'
-    aws-c-http: '>=0.7.14,<0.7.15.0a0'
-    aws-c-io: '>=0.13.36,<0.13.37.0a0'
-    aws-c-sdkutils: '>=0.1.12,<0.1.13.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.7-h4faf3ed_1.conda
-  hash:
-    md5: e2a9f779fafe385cd516c079e7c9a36b
-    sha256: 2647adb3ef4373e545308791020d6fbbeff4b57a3a1bb9f82dfc89ddf56e458e
-  category: main
-  optional: false
-- name: aws-c-mqtt
-  version: 0.9.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.8,<0.9.9.0a0'
-    aws-c-http: '>=0.7.14,<0.7.15.0a0'
-    aws-c-io: '>=0.13.36,<0.13.37.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.9.10-hba57965_1.conda
-  hash:
-    md5: c458f86f2d52f04a588c0ce72c8b2bce
-    sha256: 803ddbb520a706f8b43283f37640e1b37b132b399ceef76abb8f4b309933400e
-  category: main
-  optional: false
-- name: coloredlogs
-  version: 15.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    humanfriendly: '>=9.1'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/coloredlogs-15.0.1-pyhd8ed1ab_3.tar.bz2
-  hash:
-    md5: 7b4fc18b7f66382257c45424eaf81935
-    sha256: 0bb37abbf3367add8a8e3522405efdbd06605acfc674488ef52486968f2c119d
-  category: main
-  optional: false
-- name: importlib-metadata
-  version: 6.8.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-    zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
-  hash:
-    md5: 4e9f59a060c3be52bc4ddc46ee9b6946
-    sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
-  category: main
-  optional: false
-- name: jinja2
-  version: 3.1.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    markupsafe: '>=2.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: c8490ed5c70966d232fdd389d0dbed37
-    sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-  category: main
-  optional: false
-- name: joblib
-  version: 1.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4da50d410f553db77e62ab62ffaa1abc
-    sha256: 31e05d47970d956206188480b038829d24ac11fe8216409d8584d93d40233878
-  category: main
-  optional: false
-- name: libcblas
-  version: 3.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-20_linux64_openblas.conda
-  hash:
-    md5: 36d486d72ab64ffea932329a1d3729a3
-    sha256: 0e34fb0f82262f02fcb279ab4a1db8d50875dc98e3019452f8f387e6bf3c0247
-  category: main
-  optional: false
-- name: libgoogle-cloud
-  version: 2.12.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: '>=8.4.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libgrpc: '>=1.59.2,<1.60.0a0'
-    libprotobuf: '>=4.24.4,<4.24.5.0a0'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.1.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-h5206363_4.conda
-  hash:
-    md5: b5eb63d2683102be45d17c55021282f6
-    sha256: 82a7d211d0df165b073f9e8ba6d789c4b1c7c4882d546ca12d40f201fc3496fc
-  category: main
-  optional: false
-- name: liblapack
-  version: 3.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-20_linux64_openblas.conda
-  hash:
-    md5: 6fabc51f5e647d09cc010c40061557e0
-    sha256: ad7745b8d0f2ccb9c3ba7aaa7167d62fc9f02e45eb67172ae5f0dfb5a3b1a2cc
-  category: main
-  optional: false
-- name: mkl
-  version: 2022.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    _openmp_mutex: '>=4.5'
-    llvm-openmp: '>=15.0.6'
-    tbb: 2021.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-2022.2.1-h84fe81f_16997.conda
-  hash:
-    md5: a7ce56d5757f5b57e7daabe703ade5bb
-    sha256: 5322750d5e96ff5d96b1457db5fb6b10300f2bc4030545e940e17b57c4e96d00
-  category: main
-  optional: false
-- name: multiprocess
-  version: 0.70.15
-  manager: conda
-  platform: linux-64
-  dependencies:
-    dill: '>=0.3.6'
-    libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.15-py311h459d7ec_1.conda
-  hash:
-    md5: cebd02a02b199549a57e0d70aed7e2dc
-    sha256: eca27e6fb5fb4ee73f04ae030bce29f5daa46fea3d6abdabb91740646f0d188e
-  category: main
-  optional: false
-- name: pip
-  version: 23.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    setuptools: ''
-    wheel: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2400c0b86889f43aa52067161e1fb108
-    sha256: 435829a03e1c6009f013f29bb83de8b876c388820bf8cf69a7baeec25f6a3563
-  category: main
-  optional: false
-- name: protobuf
-  version: 4.24.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libgcc-ng: '>=12'
-    libprotobuf: '>=4.24.4,<4.24.5.0a0'
-    libstdcxx-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.24.4-py311h46cbc50_0.conda
-  hash:
-    md5: 83b241e2db8adb55d7ec110a913fea80
-    sha256: 1f664f5fc370c28809024387e2f991003fcabf8b025c787c70dbc99a8fcb2088
-  category: main
-  optional: false
-- name: python-dateutil
-  version: 2.8.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-    six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: dd999d1cc9f79e67dbb855c8924c7984
-    sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
-  category: main
-  optional: false
-- name: sentencepiece
-  version: 0.1.99
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libsentencepiece: 0.1.99
-    python_abi: 3.11.*
-    sentencepiece-python: 0.1.99
-    sentencepiece-spm: 0.1.99
-  url: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-0.1.99-h38be061_5.conda
-  hash:
-    md5: 0813c16e69189ccf172aed6485d48ecb
-    sha256: 72b08e94e4da219d4ec10d87890b179b5ea79e03e612c5d82bd60a564aaa75d2
+    md5: e6d228cd0bb74a51dd18f5bfce0b4115
+    sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
   category: main
   optional: false
 - name: sympy
@@ -2069,336 +2429,31 @@ package:
     sha256: 0025dd4e6411423903bf478d1b9fbff0cbbbe546f51c9375dfd6729ef2e1a1ac
   category: main
   optional: false
-- name: tqdm
-  version: 4.66.1
+- name: tbb
+  version: 2021.10.0
   manager: conda
   platform: linux-64
   dependencies:
-    colorama: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 03c97908b976498dcae97eb4e4f3149c
-    sha256: b61c9222af05e8c5ff27e4a4d2eb81870c21ffd7478346be3ef644b7a3759cc4
-  category: main
-  optional: false
-- name: typing-extensions
-  version: 4.8.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    typing_extensions: 4.8.0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
-  hash:
-    md5: 384462e63262a527bda564fa2d9126c0
-    sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
-  category: main
-  optional: false
-- name: urllib3
-  version: 2.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    brotli-python: '>=1.0.9'
-    pysocks: '>=1.5.6,<2.0,!=1.5.7'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f8ced8ee63830dec7ecc1be048d1470a
-    sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
-  category: main
-  optional: false
-- name: yarl
-  version: 1.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    idna: '>=2.0'
     libgcc-ng: '>=12'
-    multidict: '>=4.0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.9.2-py311h459d7ec_1.conda
-  hash:
-    md5: 132637a291f818a0e99c8ca468e92eb8
-    sha256: f25893b4c4e4432cdfa1c19631dd503e5f197704d2b9d09624520ece9a6845f0
-  category: main
-  optional: false
-- name: aiohttp
-  version: 3.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aiosignal: '>=1.1.2'
-    attrs: '>=17.3.0'
-    frozenlist: '>=1.1.1'
-    libgcc-ng: '>=12'
-    multidict: '>=4.5,<7.0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    yarl: '>=1.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.9.0-py311h459d7ec_0.conda
-  hash:
-    md5: f8622107430b609e3956250ed601ad30
-    sha256: f1e0233e814200c3bcfa081f1d0adc3200d334475aeac91917187026434a4b3f
-  category: main
-  optional: false
-- name: annotated-types
-  version: 0.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 997c29372bdbe2afee073dff71f35923
-    sha256: 3a2c98154d95cfd54daba6b7d507d31f5ba07ac2ad955c44eb041b66563193cd
-  category: main
-  optional: false
-- name: aws-c-s3
-  version: 0.4.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-auth: '>=0.7.7,<0.7.8.0a0'
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.8,<0.9.9.0a0'
-    aws-c-http: '>=0.7.14,<0.7.15.0a0'
-    aws-c-io: '>=0.13.36,<0.13.37.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    libgcc-ng: '>=12'
-    openssl: '>=3.1.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.4.1-hfadff92_0.conda
-  hash:
-    md5: 51a03f7432cc620590f050911bd6878a
-    sha256: 71832dc68eccdb70b06fc195a4f71304893f844131d8d165b308ad34eb79dfe1
-  category: main
-  optional: false
-- name: importlib_metadata
-  version: 6.8.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    importlib-metadata: '>=6.8.0,<6.8.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
-  hash:
-    md5: b279b07ce18058034e5b3606ba103a8b
-    sha256: b96e01dc42d547d6d9ceb1c5b52a5232cc04e40153534350f702c3e0418a6b3f
-  category: main
-  optional: false
-- name: libmagma
-  version: 2.7.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17'
-    _openmp_mutex: '>=4.5'
-    cudatoolkit: '>=11.2,<12'
-    libblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-    liblapack: '>=3.9.0,<4.0a0'
+    libhwloc: '>=2.9.3,<2.9.4.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmagma-2.7.2-h09159a4_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.10.0-h00ab1b0_2.conda
   hash:
-    md5: 76e23fe440b7cb9ab93544b57ddc1745
-    sha256: 608891658329f6dd4e2836e359ae82ad694768c829d7d29a71c7d050df3cb867
+    md5: eb0d5c122f42714f86a7058d1ce7b2e6
+    sha256: 79a6c48fa1df661af7ab3e4f5fa444dd305d87921be017413a8b97fd6d642328
   category: main
   optional: false
-- name: numpy
-  version: 1.26.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libblas: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-    liblapack: '>=3.9.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.2-py311h64a7726_0.conda
-  hash:
-    md5: fd2f142dcd680413b5ede5d0fb799205
-    sha256: c68b2c0ce95b79913134ec6ba2a2f1c10adcd60133afd48e4a57fdd128b694b7
-  category: main
-  optional: false
-- name: pydantic-core
-  version: 2.14.5
+- name: tk
+  version: 8.6.13
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    typing-extensions: '>=4.6.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.14.5-py311h46250e7_0.conda
-  hash:
-    md5: 9b2d1233d958079649cc8f91d814e04f
-    sha256: c546a042316c34bf6b9c5e16da4e6993f6712554c0ac5ee3f49260260789c38f
-  category: main
-  optional: false
-- name: requests
-  version: 2.31.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    certifi: '>=2017.4.17'
-    charset-normalizer: '>=2,<4'
-    idna: '>=2.5,<4'
-    python: '>=3.7'
-    urllib3: '>=1.21.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a30144e4156cdbb236f99ebb49828f8b
-    sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
-  category: main
-  optional: false
-- name: sacremoses
-  version: 0.0.53
-  manager: conda
-  platform: linux-64
-  dependencies:
-    click: ''
-    joblib: ''
-    python: '>=3.6'
-    regex: ''
-    six: ''
-    tqdm: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/sacremoses-0.0.53-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 76c3c384fe0941f1b08193736e8e277a
-    sha256: 2fdc52c648c0a0d80f2f6f484cd0933f9b553d2e568bf8b63abe444974eb75b5
-  category: main
-  optional: false
-- name: aws-crt-cpp
-  version: 0.24.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-auth: '>=0.7.7,<0.7.8.0a0'
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.8,<0.9.9.0a0'
-    aws-c-event-stream: '>=0.3.2,<0.3.3.0a0'
-    aws-c-http: '>=0.7.14,<0.7.15.0a0'
-    aws-c-io: '>=0.13.36,<0.13.37.0a0'
-    aws-c-mqtt: '>=0.9.10,<0.9.11.0a0'
-    aws-c-s3: '>=0.4.1,<0.4.2.0a0'
-    aws-c-sdkutils: '>=0.1.12,<0.1.13.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.24.7-h97e63c7_6.conda
-  hash:
-    md5: f31cf00e404ba450c317d3a5ca9820b6
-    sha256: 13897adb73768128bf5110a97bc9a1a9aa3dfdd86460edd9d2af644ed89bd774
-  category: main
-  optional: false
-- name: huggingface_hub
-  version: 0.16.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    filelock: ''
-    fsspec: ''
-    importlib-metadata: ''
-    packaging: '>=20.9'
-    python: '>=3.7.0'
-    pyyaml: '>=5.1'
-    requests: ''
-    tqdm: '>=4.42.1'
-    typing-extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.16.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1987745df86e9af7ff29d0352af8873a
-    sha256: bb5c10a9dff8213b74379c293d25abe4f887eadf2d20410286e3988fbf053b2b
-  category: main
-  optional: false
-- name: libmagma_sparse
-  version: 2.7.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17'
-    _openmp_mutex: '>=4.5'
-    cudatoolkit: '>=11.8,<12'
-    libblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-    liblapack: '>=3.9.0,<4.0a0'
-    libmagma: '>=2.7.2,<2.7.3.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmagma_sparse-2.7.2-h09b5827_1.conda
-  hash:
-    md5: 4214015e0fb5df4d793b36f5879760e1
-    sha256: 8385e88b9a3d68a679a25e2826a0841d0c5052ff1bc923ac233fa344d75e7dcf
-  category: main
-  optional: false
-- name: pandas
-  version: 2.1.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.23.5,<2.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python-dateutil: '>=2.8.1'
-    python-tzdata: '>=2022a'
-    python_abi: 3.11.*
-    pytz: '>=2020.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.1.3-py311h320fe9a_0.conda
-  hash:
-    md5: 3ea3486e16d559dfcb539070ed330a1e
-    sha256: d69759f8e5f3dcae2562e177cdfde5a45e4cd38db732301812aa558c1c80db57
-  category: main
-  optional: false
-- name: pydantic
-  version: 2.5.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    annotated-types: '>=0.4.0'
-    pydantic-core: 2.14.5
-    python: '>=3.7'
-    typing-extensions: '>=4.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.5.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3f908ebfccbfd09946961862d26bb9af
-    sha256: e3baa6424af931d8d7c5a0554b24d85faf3471df8036181d598065beed3096de
-  category: main
-  optional: false
-- name: aws-sdk-cpp
-  version: 1.11.182
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.8,<0.9.9.0a0'
-    aws-c-event-stream: '>=0.3.2,<0.3.3.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    aws-crt-cpp: '>=0.24.7,<0.24.8.0a0'
-    libcurl: '>=8.4.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.182-h8beafcf_7.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
   hash:
-    md5: fe27868256b2d2a57d8136e08cdff2bb
-    sha256: c71ca50ad5e4c806d76b3584a53b295db317ffa92bd8f28eacc2bf88a3877eee
-  category: main
-  optional: false
-- name: magma
-  version: 2.7.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17'
-    cudatoolkit: '>=11.8,<12'
-    libmagma: '>=2.7.2,<2.7.3.0a0'
-    libmagma_sparse: 2.7.2
-  url: https://conda.anaconda.org/conda-forge/linux-64/magma-2.7.2-h4aca40b_1.conda
-  hash:
-    md5: 8b99104c73b4ce6ed48b42b97c4801f7
-    sha256: 11ce651051ed0c2229f6ed052d8ecc29454f861be73c7e0dd55b1d1edd04f5c8
+    md5: d453b98d9c83e71da0741bb0ff4d76bc
+    sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
   category: main
   optional: false
 - name: tokenizers
@@ -2410,287 +2465,39 @@ package:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     openssl: '>=3.1.3,<4.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/tokenizers-0.14.1-py311h6640629_2.conda
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/tokenizers-0.14.1-py310h320607d_2.conda
   hash:
-    md5: abef7be15a5487d8bd1b877f16aedf82
-    sha256: 7d9338ccc698685307d87dcadfdf6c30e0795cd8fa6e55be16c9e4822aa0eba6
+    md5: c6b00e965b0e042ddf89cd11acf16010
+    sha256: 16b2aa36b4c281f524d24df13de5ecbce6c0935c21cf17e9320cd23500aecff8
   category: main
   optional: false
-- name: libarrow
-  version: 14.0.1
+- name: torchtriton
+  version: 2.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    aws-crt-cpp: '>=0.24.7,<0.24.8.0a0'
-    aws-sdk-cpp: '>=1.11.182,<1.11.183.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    glog: '>=0.6.0,<0.7.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libbrotlidec: '>=1.1.0,<1.2.0a0'
-    libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libgcc-ng: '>=12'
-    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
-    libre2-11: '>=2023.6.2,<2024.0a0'
-    libstdcxx-ng: '>=12'
-    libutf8proc: '>=2.8.0,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=1.9.2,<1.9.3.0a0'
-    re2: ''
-    snappy: '>=1.1.10,<2.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.1-h2b6da2a_4_cpu.conda
-  hash:
-    md5: 764b78f1b4fba866bba4135f327d1ceb
-    sha256: 4dd49028b0db6e2867c35057b0bd86b512a91c204db89dcf2cb673d284622c12
-  category: main
-  optional: false
-- name: pytorch
-  version: 2.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __cuda: ''
-    __glibc: '>=2.17,<3.0.a0'
-    _openmp_mutex: '>=4.5'
-    cudatoolkit: '>=11.8,<12'
-    cudnn: '>=8.8.0.121,<9.0a0'
     filelock: ''
-    fsspec: ''
-    jinja2: ''
-    libcblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-    libmagma: '>=2.7.2,<2.7.3.0a0'
-    libmagma_sparse: '>=2.7.2,<2.7.3.0a0'
-    libprotobuf: '>=4.24.4,<4.24.5.0a0'
-    libstdcxx-ng: '>=12'
-    libuv: '>=1.46.0,<2.0a0'
-    magma: '>=2.7.2,<2.7.3.0a0'
-    mkl: '>=2022.2.1,<2023.0a0'
-    nccl: '>=2.19.3.1,<3.0a0'
-    networkx: ''
-    numpy: '>=1.23.5,<2.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    sleef: '>=3.5.1,<4.0a0'
-    sympy: ''
-    typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.1.0-cuda118py311h3b8d1c1_300.conda
+    python: '>=3.10,<3.11.0a0'
+    pytorch: ''
+  url: https://conda.anaconda.org/pytorch/linux-64/torchtriton-2.0.0-py310.tar.bz2
   hash:
-    md5: 686dad5ed227521e35714d126ee4e2c8
-    sha256: 83da2f292a649f3412e006c365bb600c6c2ba553b02fc18a85339a508aef1c8f
+    md5: e34aa90f6d7c20babf28fc9225b2a3eb
+    sha256: 8d90fcf8d4cf62a88397ae22e1c28b2182a98d34be828f16da7b7f9c61878ead
   category: main
   optional: false
-- name: accelerate
-  version: 0.24.1
+- name: tqdm
+  version: 4.66.1
   manager: conda
   platform: linux-64
   dependencies:
-    numpy: '>=1.17'
-    packaging: '>=20.0'
-    psutil: ''
-    python: '>=3.8.0'
-    pytorch: '>=1.10.0'
-    pyyaml: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/accelerate-0.24.1-pyhd8ed1ab_0.conda
+    colorama: ''
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
   hash:
-    md5: f145fda3d83dd29c8cdb5966bea45c56
-    sha256: a897315648a9eeafaff6ca43d928c93801abbee2c3542ec17934a21ff055c1a4
-  category: main
-  optional: false
-- name: deepspeed
-  version: 0.12.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17'
-    cudatoolkit: '>=11.8,<12'
-    hjson-py: ''
-    libaio: '>=0.3.113,<0.4.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    numpy: ''
-    packaging: '>=20.0'
-    psutil: ''
-    py-cpuinfo: ''
-    pydantic: ''
-    pynvml: ''
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    pytorch: '>=2.0.0,<2.1.0a0'
-    tqdm: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/deepspeed-0.12.2-cuda118py311h2c5c81a_201.conda
-  hash:
-    md5: 8497a186d895cb5b900dfd8dd1349efd
-    sha256: f326bd41c14bcf71697b4a6dc372d78c36bfd4b0708621dcbfca9ab9671aab4a
-  category: main
-  optional: false
-- name: libarrow-acero
-  version: 14.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libarrow: 14.0.1
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.1-h59595ed_4_cpu.conda
-  hash:
-    md5: 497560810ac6fe37df1e2d0a890a2c69
-    sha256: 132fbc4e57dc67d1a61f3da54afe10f4f9566d255cf538fb8f7e3ea2d51e299d
-  category: main
-  optional: false
-- name: libarrow-flight
-  version: 14.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libarrow: 14.0.1
-    libgcc-ng: '>=12'
-    libgrpc: '>=1.59.3,<1.60.0a0'
-    libprotobuf: '>=4.24.4,<4.24.5.0a0'
-    libstdcxx-ng: '>=12'
-    ucx: '>=1.15.0,<1.16.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.1-h120cb0d_4_cpu.conda
-  hash:
-    md5: abdfe485e0d186160782a854891c5ae1
-    sha256: bd7c4e517732faf3d7a5b4194b179fc209cd24934a9cc7800e2b6cc479d0d6cc
-  category: main
-  optional: false
-- name: libarrow-gandiva
-  version: 14.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libarrow: 14.0.1
-    libgcc-ng: '>=12'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libre2-11: '>=2023.6.2,<2024.0a0'
-    libstdcxx-ng: '>=12'
-    libutf8proc: '>=2.8.0,<3.0a0'
-    openssl: '>=3.1.4,<4.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.1-hacb8726_4_cpu.conda
-  hash:
-    md5: 0a08043413f6fd8d03ad503413ac66e1
-    sha256: d55c724695789a139500fc16a83cac6985458b5e049f92df243f9882170031db
-  category: main
-  optional: false
-- name: libparquet
-  version: 14.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libarrow: 14.0.1
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libthrift: '>=0.19.0,<0.19.1.0a0'
-    openssl: '>=3.1.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.1-h352af49_4_cpu.conda
-  hash:
-    md5: 0dda61f1eb2dc47d807c1f5ec3ad0cdc
-    sha256: 812cc59632beb00006e32434e1c2e1fc6cff51647549c54edf8e0243e6086c03
-  category: main
-  optional: false
-- name: libarrow-dataset
-  version: 14.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libarrow: 14.0.1
-    libarrow-acero: 14.0.1
-    libgcc-ng: '>=12'
-    libparquet: 14.0.1
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.1-h59595ed_4_cpu.conda
-  hash:
-    md5: 1a4c89f8a071976813de665b3fba5a04
-    sha256: 8d2bb27800eb8ccc6818eee0a6320ba2c0c8899c8cc1757026bca694069a7d45
-  category: main
-  optional: false
-- name: libarrow-flight-sql
-  version: 14.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libarrow: 14.0.1
-    libarrow-flight: 14.0.1
-    libgcc-ng: '>=12'
-    libprotobuf: '>=4.24.4,<4.24.5.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.1-h61ff412_4_cpu.conda
-  hash:
-    md5: 69468e4ea6ab681fd218b0abc2084cbb
-    sha256: a0ad5c7613132e6903fc929c001466785e88d4ae1c0b04e49605f1366eb4dbae
-  category: main
-  optional: false
-- name: libarrow-substrait
-  version: 14.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libarrow: 14.0.1
-    libarrow-acero: 14.0.1
-    libarrow-dataset: 14.0.1
-    libgcc-ng: '>=12'
-    libprotobuf: '>=4.24.4,<4.24.5.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.1-h61ff412_4_cpu.conda
-  hash:
-    md5: 44127a40001dba3cc6fbdfcd5331bc51
-    sha256: d1af57d44adfb51f354bdd65a7a8f93595c57fd3a1e5b8b9285f6315a122acc5
-  category: main
-  optional: false
-- name: pyarrow
-  version: 14.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libarrow: 14.0.1
-    libarrow-acero: 14.0.1
-    libarrow-dataset: 14.0.1
-    libarrow-flight: 14.0.1
-    libarrow-flight-sql: 14.0.1
-    libarrow-gandiva: 14.0.1
-    libarrow-substrait: 14.0.1
-    libgcc-ng: '>=12'
-    libparquet: 14.0.1
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.23.5,<2.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.1-py311h39c9aba_4_cpu.conda
-  hash:
-    md5: 95f7ef34dbc15c5d714fdb0f02ff0d00
-    sha256: d3c24ac39ed0b21a2c15a3b6cfa9b24148b0eaf5d6c69dd93a1260ce0d7795fe
-  category: main
-  optional: false
-- name: datasets
-  version: 2.14.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aiohttp: ''
-    dill: '>=0.3.0,<0.3.8'
-    fsspec: '>=2023.1.0,<2023.9.0'
-    huggingface_hub: '>=0.14.0,<1.0.0'
-    importlib-metadata: ''
-    multiprocess: ''
-    numpy: '>=1.17'
-    packaging: ''
-    pandas: ''
-    pyarrow: '>=8.0.0'
-    python: '>=3.8.0'
-    python-xxhash: ''
-    pyyaml: '>=5.1'
-    requests: '>=2.19.0'
-    tqdm: '>=4.62.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.14.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3bec9fb1eeef5a6e316011f2a3543ffd
-    sha256: d3ecb2e0fbcec7fd6825cf032190eec6a0aa9c575498dcb71db96acedfb730d7
+    md5: 03c97908b976498dcae97eb4e4f3149c
+    sha256: b61c9222af05e8c5ff27e4a4d2eb81870c21ffd7478346be3ef644b7a3759cc4
   category: main
   optional: false
 - name: transformers
@@ -2719,74 +2526,162 @@ package:
     sha256: 3836d0d338ce6a713b069270deaba44e352f587f09c02015aaa62e3f2ee375b6
   category: main
   optional: false
-- name: optimum
-  version: 1.13.2
+- name: typing-extensions
+  version: 4.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    coloredlogs: ''
-    datasets: ''
-    huggingface_hub: '>=0.8.0'
-    numpy: ''
-    packaging: ''
-    protobuf: ''
-    python: '>=3.7'
-    pytorch: '>=1.9'
-    sentencepiece: '>=0.1.91'
-    sympy: ''
-    transformers: '>=4.26.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/optimum-1.13.2-pyhd8ed1ab_0.conda
+    typing_extensions: 4.8.0
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
   hash:
-    md5: 7bc29f1226e7e63bceed63fa46e09322
-    sha256: 4fa7a2cde0426cbc000aa1db96639d86122a172364aff262fecccfa0e2a57004
+    md5: 384462e63262a527bda564fa2d9126c0
+    sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
   category: main
   optional: false
-- name: ninja
-  version: 1.11.1
-  manager: pip
-  platform: linux-64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/0f/58/854ce5aab0ff5c33d66e1341b0be42f0330797335011880f7fbd88449996/ninja-1.11.1-py2.py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
-  hash:
-    sha256: 817e2aee2a4d28a708a67bcfba1817ae502c32c6d8ef80e50d63b0f23adf3a08
-  category: main
-  optional: false
-- name: safetensors
-  version: 0.3.1
-  manager: pip
-  platform: linux-64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/a9/3e/28bd47b8d0f709b680d9e5d5ff715df187adb1f806fde72478049d691873/safetensors-0.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  hash:
-    sha256: 997a2cc14023713f423e6d16536d55cb16a3d72850f142e05f82f0d4c76d383b
-  category: main
-  optional: false
-- name: sentencepiece
-  version: 0.1.99
-  manager: pip
-  platform: linux-64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/4d/9d/9153942f0e2143a43978bcefba31d79187b7037bed3f85a6668c69493062/sentencepiece-0.1.99-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  hash:
-    sha256: db361e03342c41680afae5807590bc88aa0e17cfd1a42696a160e4005fcda03b
-  category: main
-  optional: false
-- name: exllama
-  version: 0.1.0
-  manager: pip
+- name: typing_extensions
+  version: 4.8.0
+  manager: conda
   platform: linux-64
   dependencies:
-    ninja: 1.11.1
-    safetensors: 0.3.1
-    sentencepiece: '>=0.1.97'
-    torch: '>=2.0.1'
-  url: https://files.pythonhosted.org/packages/cd/15/d1c31f0cabab5a66cdfc34b27cac1bbe564213a9be8c077eb49e0ce16b41/exllama-0.1.0-py3-none-any.whl
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
   hash:
-    sha256: f12f27686fbcaaa74298626eb5e8182f39207f2e0db2d28e8634bc2d8124a75d
+    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
+  category: main
+  optional: false
+- name: tzdata
+  version: 2023c
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+  hash:
+    md5: 939e3e74d8be4dac89ce83b20de2492a
+    sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
+  category: main
+  optional: false
+- name: ucx
+  version: 1.15.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libnuma: '>=2.0.16,<3.0a0'
+    libstdcxx-ng: '>=12'
+    rdma-core: '>=48.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-hae80064_1.conda
+  hash:
+    md5: c0413425844278251c1cc9459386339b
+    sha256: f511a735bf7a0b56c5ae48839e2248d46a922ffc6ad8ea2da7617485faa70c6f
+  category: main
+  optional: false
+- name: urllib3
+  version: 2.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    brotli-python: '>=1.0.9'
+    pysocks: '>=1.5.6,<2.0,!=1.5.7'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: f8ced8ee63830dec7ecc1be048d1470a
+    sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
+  category: main
+  optional: false
+- name: wheel
+  version: 0.42.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1cdea58981c5cbc17b51973bcaddcea7
+    sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
+  category: main
+  optional: false
+- name: xxhash
+  version: 0.8.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xxhash-0.8.2-hd590300_0.conda
+  hash:
+    md5: f08fb5c89edfc4aadee1c81d4cfb1fa1
+    sha256: 6fe74a8fd84ab0dc25e4dc3e0c22388dd8accb212897a208b14fe5d4fbb8fc2f
+  category: main
+  optional: false
+- name: xz
+  version: 5.2.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  hash:
+    md5: 2161070d867d1b1204ea749c8eec4ef0
+    sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  category: main
+  optional: false
+- name: yaml
+  version: 0.2.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=9.4.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  hash:
+    md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+    sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  category: main
+  optional: false
+- name: yarl
+  version: 1.9.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    idna: '>=2.0'
+    libgcc-ng: '>=12'
+    multidict: '>=4.0'
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.9.3-py310h2372a71_0.conda
+  hash:
+    md5: 10246f66639d9ca55e790410f0dbb465
+    sha256: 159e9e292f841477dd1e4c897c055d364472720c79b16fa329faee1e7b878564
+  category: main
+  optional: false
+- name: zipp
+  version: 3.17.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+  hash:
+    md5: 04b88013080254850d6c01ed54810589
+    sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
   category: main
   optional: false
 - name: flash-attn
-  version: 2.3.3
+  version: 2.3.6
   manager: pip
   platform: linux-64
   dependencies:
@@ -2794,56 +2689,18 @@ package:
     einops: '*'
     packaging: '*'
     ninja: '*'
-  url: https://files.pythonhosted.org/packages/fa/d5/8285a20ed850824c9c0917dff851571f0b18402db8a52c20b7486d4d70d7/flash_attn-2.3.3.tar.gz
+  url: https://files.pythonhosted.org/packages/3c/49/95b86adfc0d90676dcb07fcbef47c71997e6e7c9e71fda51598a962d9148/flash_attn-2.3.6.tar.gz
   hash:
-    sha256: 489e0197842a6f21f15a1a44d2d26553bae9d63d00fe8cb51afec73f0e578df1
+    sha256: 4fc6c08714ee1c88178946465498677c59448429b43bd6244b222feb23ac9d4c
   category: main
   optional: false
-- name: peft
-  version: 0.6.1
+- name: ninja
+  version: 1.11.1.1
   manager: pip
   platform: linux-64
-  dependencies:
-    numpy: '>=1.17'
-    packaging: '>=20.0'
-    psutil: '*'
-    pyyaml: '*'
-    torch: '>=1.13.0'
-    transformers: '*'
-    tqdm: '*'
-    accelerate: '>=0.21.0'
-    safetensors: '*'
-  url: https://files.pythonhosted.org/packages/d0/a6/c5442d9172fae3554f8d83699a1c05015152f7c84fef934eeb81cbfec4f8/peft-0.6.1-py3-none-any.whl
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/6d/92/8d7aebd4430ab5ff65df2bfee6d5745f95c004284db2d8ca76dcbfd9de47/ninja-1.11.1.1-py2.py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl
   hash:
-    sha256: 362e7eb4e551b1de1af7dbbc84e3c7049b618ce90a0824a4abfda31b69a7ed0d
-  category: main
-  optional: false
-- name: rouge
-  version: 1.0.1
-  manager: pip
-  platform: linux-64
-  dependencies:
-    six: '*'
-  url: https://files.pythonhosted.org/packages/32/7c/650ae86f92460e9e8ef969cc5008b24798dcf56a9a8947d04c78f550b3f5/rouge-1.0.1-py3-none-any.whl
-  hash:
-    sha256: 28d118536e8c774dc47d1d15ec266479b4dd0914c4672ce117d4002789bdc644
-  category: main
-  optional: false
-- name: auto-gptq
-  version: 0.4.2
-  manager: pip
-  platform: linux-64
-  dependencies:
-    accelerate: '>=0.19.0'
-    datasets: '*'
-    numpy: '*'
-    rouge: '*'
-    torch: '>=1.13.0'
-    safetensors: '*'
-    transformers: '>=4.31.0'
-    peft: '*'
-  url: https://files.pythonhosted.org/packages/38/d3/f404ee986f2e1f9fa744296365b0bfbbf3d3a779a2b2dc92e54e919ca297/auto_gptq-0.4.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  hash:
-    sha256: c0f39d23b9fe8d823e49dc3cc3686472f2d4dea9cb7bd531a761155c9cf38bbf
+    sha256: 84502ec98f02a037a169c4b0d5d86075eaf6afc55e1879003d6cab51ced2ea4b
   category: main
   optional: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yi-models"
-version = "0.1.0-dev"
+version = "0.1.0"
 description = ""
 authors = ["Yi Team <yi@01.ai>"]
 license = "Apache 2.0"
@@ -11,7 +11,7 @@ python = "^3.10"
 pytorch = "2.1.0"
 pytorch-cuda = "11.8"
 deepspeed = "0.12.2"
-transformers = "4.34.0"
+transformers = "4.35.0"
 sentencepiece = "0.1.99"
 accelerate = "0.24.1"
 datasets = "2.14.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ license = "Apache 2.0"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.10"
-pytorch = "2.1.0"
+python = "~3.10"
+pytorch = "2.0.1"
 pytorch-cuda = "11.8"
 deepspeed = "0.12.2"
 transformers = "4.35.0"
@@ -17,9 +17,7 @@ accelerate = "0.24.1"
 datasets = "2.14.5"
 optimum = "1.13.2"
 einops = "0.7.0"
-exllama = {version = "0.1.0", source = "pypi"}
-auto-gptq = {version = "0.4.2", source = "pypi"}
-flash-attn = {version = "2.3.3", source = "pypi"}
+flash-attn = {version = "2.3.6", source = "pypi"}
 
 [tool.conda-lock]
 channels = ["conda-forge", "pytorch", "nvidia", "nodefaults"]


### PR DESCRIPTION
This PR upgrades the version of `transformers` to `v4.35.0` so that we can run our chat models.