### PR TITLE
add openai api support

### DIFF
--- a/demo/openai_api_demo/openai_api.py
+++ b/demo/openai_api_demo/openai_api.py
@@ -1,0 +1,731 @@
+import gc
+import traceback
+import torch
+import uvicorn
+import time
+import uuid
+import anyio
+import json
+from anyio.streams.memory import MemoryObjectSendStream
+from functools import lru_cache
+from abc import ABC
+from threading import Lock, Thread
+from types import MethodType
+from argparse import ArgumentParser
+from contextlib import asynccontextmanager
+from functools import partial
+from typing import Dict, List, Any, Optional, Union, Tuple, Iterator, Iterable, AsyncIterator
+from loguru import logger
+from starlette.concurrency import run_in_threadpool, iterate_in_threadpool
+from sse_starlette import EventSourceResponse
+from pydantic import BaseModel
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+from openai.types.model import Model
+from openai.types.chat.chat_completion_message import FunctionCall
+from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
+from openai.types.completion_usage import CompletionUsage
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
+from openai.types.chat.chat_completion_chunk import (
+    ChoiceDelta,
+    ChoiceDeltaFunctionCall,
+    ChoiceDeltaToolCall,
+)
+from openai.types.chat import (
+    ChatCompletionMessage,
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionMessageParam,
+)
+
+from transformers import AutoTokenizer, AutoModelForCausalLM, TextIteratorStreamer, PreTrainedModel
+from transformers.generation import GenerationConfig
+
+from utils import (
+    Role, 
+    ModelList, 
+    ChatCompletionCreateParams,
+    CompletionCreateParams,
+    ErrorCode,
+    ErrorResponse,
+    model_dump,
+    model_parse,
+    model_json,
+    get_context_length,
+    apply_stopping_strings,
+    load_model_on_gpus)
+
+
+llama_outer_lock = Lock()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):  # collects GPU memory
+    yield
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+        torch.cuda.ipc_collect()
+
+
+app = FastAPI(lifespan=lifespan)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/v1/models")
+async def list_models():
+    return ModelList(
+    data=[
+        Model(
+            id="yi",
+            object="model",
+            created=int(time.time()),
+            owned_by="open"
+        )
+    ]
+)
+
+
+@app.post("/v1/chat/completions")
+async def create_chat_completion(
+    request: ChatCompletionCreateParams,
+    raw_request: Request
+):
+    global model, tokenizer
+
+    if len(request.messages) < 1 or request.messages[-1]["role"] == Role.ASSISTANT:
+        raise HTTPException(status_code=400, detail="Invalid request")
+
+    request = await handle_request(request, template.stop)
+    request.max_tokens = request.max_tokens or 1024
+
+    params = model_dump(request)
+    params.update(dict(echo=False))
+    logger.debug(f"==== request ====\n{params}")
+
+    iterator_or_completion = await run_in_threadpool(_create_chat_completion, params)
+
+    if isinstance(iterator_or_completion, Iterator):
+        # It's easier to ask for forgiveness than permission
+        first_response = await run_in_threadpool(next, iterator_or_completion)
+
+        # If no exception was raised from first_response, we can assume that
+        # the iterator is valid, and we can use it to stream the response.
+        def iterator() -> Iterator:
+            yield first_response
+            yield from iterator_or_completion
+
+        send_chan, recv_chan = anyio.create_memory_object_stream(10)
+        return EventSourceResponse(
+            recv_chan,
+            data_sender_callable=partial(
+                get_event_publisher,
+                request=raw_request,
+                inner_send_chan=send_chan,
+                iterator=iterator(),
+            ),
+        )
+    else:
+        return iterator_or_completion
+
+
+def _create_chat_completion(
+    params: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -> Union[Iterator, ChatCompletion]:
+    params = params or {}
+    params.update(kwargs)
+    return (
+        _create_chat_completion_stream(params)
+        if params.get("stream", False)
+        else _create_chat_completion_non_stream(params)
+    )
+
+
+def _create_chat_completion_stream(params: Dict[str, Any]) -> Iterator:
+    """
+    Creates a chat completion stream.
+
+    Args:
+        params (Dict[str, Any]): The parameters for generating the chat completion.
+
+    Yields:
+        Dict[str, Any]: The output of the chat completion stream.
+    """
+    _id, _created, _model = None, None, None
+    has_function_call = False
+    for i, output in enumerate(_generate(params)):
+        if output["error_code"] != 0:
+            yield output
+            return
+
+        _id, _created, _model = output["id"], output["created"], output["model"]
+        if i == 0:
+            choice = ChunkChoice(
+                index=0,
+                delta=ChoiceDelta(role="assistant", content=""),
+                finish_reason=None,
+            )
+            yield ChatCompletionChunk(
+                id=f"chat{_id}",
+                choices=[choice],
+                created=_created,
+                model=_model,
+                object="chat.completion.chunk",
+            )
+
+        finish_reason = output["finish_reason"]
+        if len(output["delta"]) == 0 and finish_reason != "function_call":
+            continue
+
+        function_call = None
+        if finish_reason == "function_call":
+            try:
+                _, function_call = template.parse_assistant_response(
+                    output["text"], params.get("functions"), params.get("tools"),
+                )
+            except Exception as e:
+                traceback.print_exc()
+                logger.warning("Failed to parse tool call")
+
+        if isinstance(function_call, dict) and "arguments" in function_call:
+            has_function_call = True
+            function_call = ChoiceDeltaFunctionCall(**function_call)
+            delta = ChoiceDelta(
+                content=output["delta"],
+                function_call=function_call
+            )
+        elif isinstance(function_call, dict) and "function" in function_call:
+            has_function_call = True
+            finish_reason = "tool_calls"
+            function_call["index"] = 0
+            tool_calls = [model_parse(ChoiceDeltaToolCall, function_call)]
+            delta = ChoiceDelta(
+                content=output["delta"],
+                tool_calls=tool_calls,
+            )
+        else:
+            delta = ChoiceDelta(content=output["delta"])
+
+        choice = ChunkChoice(
+            index=0,
+            delta=delta,
+            finish_reason=finish_reason
+        )
+        yield ChatCompletionChunk(
+            id=f"chat{_id}",
+            choices=[choice],
+            created=_created,
+            model=_model,
+            object="chat.completion.chunk",
+        )
+
+    if not has_function_call:
+        choice = ChunkChoice(
+            index=0,
+            delta=ChoiceDelta(),
+            finish_reason="stop"
+        )
+        yield ChatCompletionChunk(
+            id=f"chat{_id}",
+            choices=[choice],
+            created=_created,
+            model=_model,
+            object="chat.completion.chunk",
+        )
+
+
+def _create_chat_completion_non_stream(params: Dict[str, Any]) -> Union[ChatCompletion, JSONResponse]:
+    """
+    Creates a chat completion based on the given parameters.
+
+    Args:
+        params (Dict[str, Any]): The parameters for generating the chat completion.
+
+    Returns:
+        ChatCompletion: The generated chat completion.
+    """
+    last_output = None
+    for output in _generate(params):
+        last_output = output
+
+    if last_output["error_code"] != 0:
+        return create_error_response(last_output["error_code"], last_output["text"])
+
+    function_call, finish_reason = None, "stop"
+    if params.get("functions") or params.get("tools"):
+        try:
+            res, function_call = template.parse_assistant_response(
+                last_output["text"], params.get("functions"), params.get("tools"),
+            )
+            last_output["text"] = res
+        except Exception as e:
+            traceback.print_exc()
+            logger.warning("Failed to parse tool call")
+
+    if isinstance(function_call, dict) and "arguments" in function_call:
+        finish_reason = "function_call"
+        function_call = FunctionCall(**function_call)
+        message = ChatCompletionMessage(
+            role="assistant",
+            content=last_output["text"],
+            function_call=function_call,
+        )
+    elif isinstance(function_call, dict) and "function" in function_call:
+        finish_reason = "tool_calls"
+        tool_calls = [model_parse(ChatCompletionMessageToolCall, function_call)]
+        message = ChatCompletionMessage(
+            role="assistant",
+            content=last_output["text"],
+            tool_calls=tool_calls,
+        )
+    else:
+        message = ChatCompletionMessage(
+            role="assistant",
+            content=last_output["text"].strip(),
+        )
+
+    choice = Choice(
+        index=0,
+        message=message,
+        finish_reason=finish_reason,
+    )
+    usage = model_parse(CompletionUsage, last_output["usage"])
+    return ChatCompletion(
+        id=f"chat{last_output['id']}",
+        choices=[choice],
+        created=last_output["created"],
+        model=last_output["model"],
+        object="chat.completion",
+        usage=usage,
+    )
+
+
+def _generate(params: Dict[str, Any]) -> Iterator:
+    """
+    Generates text based on the given parameters.
+
+    Args:
+        params (Dict[str, Any]): A dictionary containing the parameters for text generation.
+
+    Yields:
+        Iterator: A dictionary containing the generated text and error code.
+    """
+    messages = params.get("messages")
+    inputs, prompt = _apply_chat_template(
+        messages,
+        max_new_tokens=params.get("max_tokens", 256),
+        functions=params.get("functions"),
+        tools=params.get("tools"),
+    )
+
+    params.update(dict(inputs=inputs, prompt=prompt))
+
+    try:
+        for output in _generate_stream_func(params):
+            output["error_code"] = 0
+            yield output
+
+    except (ValueError, RuntimeError) as e:
+        traceback.print_exc()
+        yield {
+            "text": f"{e}",
+            "error_code": ErrorCode.INTERNAL_ERROR,
+        }
+
+
+def _apply_chat_template(
+    messages: List[ChatCompletionMessageParam],
+    max_new_tokens: Optional[int] = 256,
+    functions: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
+    tools: Optional[List[Dict[str, Any]]] = None,
+) -> Tuple[Union[List[int], Dict[str, Any]], Optional[str]]:
+    """
+    Apply chat template to generate model inputs and prompt.
+
+    Args:
+        messages (List[ChatCompletionMessageParam]): List of chat completion message parameters.
+        max_new_tokens (Optional[int], optional): Maximum number of new tokens to generate. Defaults to 256.
+        functions (Optional[Union[Dict[str, Any], List[Dict[str, Any]]]], optional): Functions to apply to the messages. Defaults to None.
+        tools (Optional[List[Dict[str, Any]]], optional): Tools to apply to the messages. Defaults to None.
+        **kwargs: Additional keyword arguments.
+
+    Returns:
+        Tuple[Union[List[int], Dict[str, Any]], Union[str, None]]: Tuple containing the generated inputs and prompt.
+    """
+    if template.function_call_available:
+        messages = template.postprocess_messages(
+            messages, functions, tools=tools,
+        )
+        if functions or tools:
+            logger.debug(f"==== Messages with tools ====\n{messages}")
+
+    prompt = template.apply_chat_template(messages)
+    inputs = tokenizer(prompt).input_ids
+    if isinstance(inputs, list):
+        max_src_len = context_len - max_new_tokens - 1
+        inputs = inputs[-max_src_len:]
+    
+    return inputs, prompt
+
+
+
+@torch.inference_mode()
+def _generate_stream_func(
+    params: Dict[str, Any],
+):
+    input_ids = params.get("inputs")
+    functions = params.get("functions")
+    model_name = params.get("model", "llm")
+    temperature = float(params.get("temperature", 1.0))
+    repetition_penalty = float(params.get("repetition_penalty", 1.0))
+    top_p = float(params.get("top_p", 1.0))
+    top_k = int(params.get("top_k", 40))
+    max_new_tokens = int(params.get("max_tokens", 256))
+
+    stop_token_ids = params.get("stop_token_ids") or []
+    if tokenizer.eos_token_id not in stop_token_ids:
+        stop_token_ids.append(tokenizer.eos_token_id)
+    stop_strings = params.get("stop", [])
+
+    input_echo_len = len(input_ids)
+    device = model.device
+    generation_kwargs = dict(
+        input_ids=torch.tensor([input_ids], device=device),
+        do_sample=True,
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        max_new_tokens=max_new_tokens,
+        repetition_penalty=repetition_penalty,
+        pad_token_id=tokenizer.pad_token_id,
+    )
+    if temperature <= 1e-5:
+        generation_kwargs["do_sample"] = False
+        generation_kwargs.pop("top_k")
+
+    streamer = TextIteratorStreamer(
+        tokenizer, timeout=60.0, skip_prompt=True, skip_special_tokens=True
+    )
+    generation_kwargs["streamer"] = streamer
+
+    if "GenerationMixin" not in str(model.generate.__func__):
+        model.generate = MethodType(PreTrainedModel.generate, model)
+
+    thread = Thread(target=model.generate, kwargs=generation_kwargs)
+    thread.start()
+
+    generated_text, func_call_found = "", False
+    completion_id: str = f"cmpl-{str(uuid.uuid4())}"
+    created: int = int(time.time())
+    previous_text = ""
+    for i, new_text in enumerate(streamer):
+        generated_text += new_text
+        if functions:
+            _, func_call_found = apply_stopping_strings(generated_text, ["Observation:"])
+        generated_text, stop_found = apply_stopping_strings(generated_text, stop_strings)
+
+        if generated_text and generated_text[-1] != "�":
+            delta_text = generated_text[len(previous_text):]
+            previous_text = generated_text
+
+            yield {
+                "id": completion_id,
+                "object": "text_completion",
+                "created": created,
+                "model": model_name,
+                "delta": delta_text,
+                "text": generated_text,
+                "logprobs": None,
+                "finish_reason": "function_call" if func_call_found else None,
+                "usage": {
+                    "prompt_tokens": input_echo_len,
+                    "completion_tokens": i,
+                    "total_tokens": input_echo_len + i,
+                },
+            }
+
+        if stop_found:
+            break
+
+    yield {
+        "id": completion_id,
+        "object": "text_completion",
+        "created": created,
+        "model": model_name,
+        "delta": "",
+        "text": generated_text,
+        "logprobs": None,
+        "finish_reason": "stop",
+        "usage": {
+            "prompt_tokens": input_echo_len,
+            "completion_tokens": i,
+            "total_tokens": input_echo_len + i,
+        },
+    }
+
+
+class YiAITemplate(ABC):
+    """ https://huggingface.co/01-ai/Yi-34B-Chat/blob/main/tokenizer_config.json """
+
+    name = "yi"
+    system_prompt: Optional[str] = ""
+    allow_models = ["yi"]
+    stop = {
+        "strings": ["<|endoftext|>", "<|im_end|>"],
+        "token_ids": [2, 6, 7, 8],  # "<|endoftext|>", "<|im_start|>", "<|im_end|>", "<|im_sep|>"
+    }
+    function_call_available: Optional[bool] = False
+
+    def apply_chat_template(
+        self,
+        conversation: List[ChatCompletionMessageParam],
+        add_generation_prompt: bool = True,
+    ) -> str:
+        """
+        Converts a Conversation object or a list of dictionaries with `"role"` and `"content"` keys to a prompt.
+
+        Args:
+            conversation (List[ChatCompletionMessageParam]): A Conversation object or list of dicts
+                with "role" and "content" keys, representing the chat history so far.
+            add_generation_prompt (bool, *optional*): Whether to end the prompt with the token(s) that indicate
+                the start of an assistant message. This is useful when you want to generate a response from the model.
+                Note that this argument will be passed to the chat template, and so it must be supported in the
+                template for this argument to have any effect.
+
+        Returns:
+            `str`: A prompt, which is ready to pass to the tokenizer.
+        """
+        # Compilation function uses a cache to avoid recompiling the same template
+        compiled_template = _compile_jinja_template(self.template)
+        return compiled_template.render(
+            messages=conversation,
+            add_generation_prompt=add_generation_prompt,
+            system_prompt=self.system_prompt,
+        )
+    
+    @property
+    def template(self) -> str:
+        return (
+            "{% for message in messages %}"
+            "{{ '<|im_start|>' + message['role'] + '\\n' + message['content'] + '<|im_end|>' + '\\n' }}"
+            "{% endfor %}"
+            "{% if add_generation_prompt %}"
+            "{{ '<|im_start|>assistant\\n' }}"
+            "{% endif %}"
+        )
+
+    def postprocess_messages(
+        self,
+        messages: List[ChatCompletionMessageParam],
+        functions: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+    ) -> List[Dict[str, Any]]:
+        return messages
+    
+    def parse_assistant_response(
+        self,
+        output: str,
+        functions: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+    ) -> Tuple[str, Optional[Union[str, Dict[str, Any]]]]:
+        return output, None
+
+
+@lru_cache
+def _compile_jinja_template(chat_template: str):
+    """
+    Compile a Jinja template from a string.
+
+    Args:
+        chat_template (str): The string representation of the Jinja template.
+
+    Returns:
+        jinja2.Template: The compiled Jinja template.
+
+    Examples:
+        >>> template_string = "Hello, {{ name }}!"
+        >>> template = _compile_jinja_template(template_string)
+    """
+    try:
+        from jinja2.exceptions import TemplateError
+        from jinja2.sandbox import ImmutableSandboxedEnvironment
+    except ImportError:
+        raise ImportError("apply_chat_template requires jinja2 to be installed.")
+
+    def raise_exception(message):
+        raise TemplateError(message)
+
+    jinja_env = ImmutableSandboxedEnvironment(trim_blocks=True, lstrip_blocks=True)
+    jinja_env.globals["raise_exception"] = raise_exception
+    return jinja_env.from_string(chat_template)
+
+
+async def handle_request(
+        request: Union[CompletionCreateParams, ChatCompletionCreateParams],
+        stop: Dict[str, Any] = None
+) -> Union[Union[CompletionCreateParams, ChatCompletionCreateParams], JSONResponse]:
+    error_check_ret = check_requests(request)
+    if error_check_ret is not None:
+        raise error_check_ret
+    
+    # stop settings
+    _stop, _stop_token_ids = [], []
+    if stop is not None:
+        _stop_token_ids = stop.get("token_ids", [])
+        _stop = stop.get("strings", [])
+
+    request.stop = request.stop or []
+    if isinstance(request.stop, str):
+        request.stop = [request.stop]
+
+    if request.functions:
+        request.stop.append("Observation:")
+
+    request.stop = list(set(_stop + request.stop))
+    request.stop_token_ids = request.stop_token_ids or []
+    request.stop_token_ids = list(set(_stop_token_ids + request.stop_token_ids))
+
+    return request
+
+
+def check_requests(request: Union[CompletionCreateParams, ChatCompletionCreateParams]) -> Optional[JSONResponse]:
+    # Check all params
+    if request.max_tokens is not None and request.max_tokens <= 0:
+        return create_error_response(
+            ErrorCode.PARAM_OUT_OF_RANGE,
+            f"{request.max_tokens} is less than the minimum of 1 - 'max_tokens'",
+        )
+    if request.n is not None and request.n <= 0:
+        return create_error_response(
+            ErrorCode.PARAM_OUT_OF_RANGE,
+            f"{request.n} is less than the minimum of 1 - 'n'",
+        )
+    if request.temperature is not None and request.temperature < 0:
+        return create_error_response(
+            ErrorCode.PARAM_OUT_OF_RANGE,
+            f"{request.temperature} is less than the minimum of 0 - 'temperature'",
+        )
+    if request.temperature is not None and request.temperature > 2:
+        return create_error_response(
+            ErrorCode.PARAM_OUT_OF_RANGE,
+            f"{request.temperature} is greater than the maximum of 2 - 'temperature'",
+        )
+    if request.top_p is not None and request.top_p < 0:
+        return create_error_response(
+            ErrorCode.PARAM_OUT_OF_RANGE,
+            f"{request.top_p} is less than the minimum of 0 - 'top_p'",
+        )
+    if request.top_p is not None and request.top_p > 1:
+        return create_error_response(
+            ErrorCode.PARAM_OUT_OF_RANGE,
+            f"{request.top_p} is greater than the maximum of 1 - 'temperature'",
+        )
+    if request.stop is None or isinstance(request.stop, (str, list)):
+        return None
+    else:
+        return create_error_response(
+            ErrorCode.PARAM_OUT_OF_RANGE,
+            f"{request.stop} is not valid under any of the given schemas - 'stop'",
+        )
+
+
+def create_error_response(code: int, message: str) -> JSONResponse:
+    return JSONResponse(model_dump(ErrorResponse(message=message, code=code)), status_code=500)
+    
+
+async def get_event_publisher(
+    request: Request,
+    inner_send_chan: MemoryObjectSendStream,
+    iterator: Union[Iterator, AsyncIterator],
+):
+    async with inner_send_chan:
+        try:
+            async for chunk in iterate_in_threadpool(iterator):
+                if isinstance(chunk, BaseModel):
+                    chunk = model_json(chunk)
+                elif isinstance(chunk, dict):
+                    chunk = json.dumps(chunk, ensure_ascii=False)
+
+                await inner_send_chan.send(dict(data=chunk))
+
+                if await request.is_disconnected():
+                    raise anyio.get_cancelled_exc_class()()
+
+                if llama_outer_lock.locked():
+                    await inner_send_chan.send(dict(data="[DONE]"))
+                    raise anyio.get_cancelled_exc_class()()
+        except anyio.get_cancelled_exc_class() as e:
+            logger.info("disconnected")
+            with anyio.move_on_after(1, shield=True):
+                logger.info(f"Disconnected from client (via refresh/close) {request.client}")
+                raise e
+
+
+def _get_args():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "-c",
+        "--checkpoint-path",
+        type=str,
+        default="01-ai/Yi-6B-Chat/",
+        help="Checkpoint name or path, default to %(default)r",
+    )
+    parser.add_argument(
+        "--cpu-only", action="store_true", help="Run demo with CPU only"
+    )
+    parser.add_argument(
+        "--server-port", type=int, default=8000, help="Demo server port."
+    )
+    parser.add_argument(
+        "--server-name",
+        type=str,
+        default="127.0.0.1",
+        help="Demo server name. Default: 127.0.0.1, which is only visible from the local computer."
+        " If you want other computers to access your server, use 0.0.0.0 instead.",
+    )
+    parser.add_argument(
+        "--context_len", type=int, default=None, help="Context length for generating completions."
+    )
+    parser.add_argument("--disable-gc", action="store_true",
+                        help="Disable GC after each response generated.")
+
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == "__main__":
+    args = _get_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.checkpoint_path
+    )
+
+    if args.cpu_only:
+        device = "cpu"
+    else:
+        device = "cuda"
+
+    model = AutoModelForCausalLM.from_pretrained(
+        args.checkpoint_path,
+        torch_dtype='auto'
+    ).to(device).eval()
+
+    model.generation_config = GenerationConfig.from_pretrained(
+        args.checkpoint_path
+    )
+
+    context_len = get_context_length(model.config) if args.context_len is None else args.context_len
+    template = YiAITemplate()
+
+    uvicorn.run(app, host=args.server_name, port=args.server_port, workers=1)

--- a/demo/openai_api_demo/openai_api_request.py
+++ b/demo/openai_api_demo/openai_api_request.py
@@ -1,0 +1,47 @@
+from openai import OpenAI
+
+# To start an Latest OpenAI-like Yi server, use the following commands:
+#   git clone https://github.com/01-ai/Yi;
+#   cd Yi;
+#   pip install fastapi uvicorn openai pydantic sse_starlette;
+#   python demo/openai_api_demo/openai_api.py;
+#
+# Then configure the api_base and api_key in your client:
+client = OpenAI(
+    api_key="EMPTY",
+    base_url="http://localhost:8000/v1/",
+)
+
+
+# List models API
+models = client.models.list()
+print(models.model_dump())
+
+
+# Chat completion API
+chat_completion = client.chat.completions.create(
+    messages=[
+        {
+            "role": "user",
+            "content": "你好，请问你是谁？",
+        }
+    ],
+    model="yi",
+)
+print(chat_completion)
+
+
+# Stream
+stream = client.chat.completions.create(
+    messages=[
+        {
+            "role": "user",
+            "content": "你好，请问你是谁？",
+        }
+    ],
+    model="yi",
+    stream=True,
+)
+for part in stream:
+    print(part.choices[0].delta.content or "", end="", flush=True)
+

--- a/demo/openai_api_demo/utils.py
+++ b/demo/openai_api_demo/utils.py
@@ -1,0 +1,622 @@
+import pydantic
+import torch
+from enum import Enum, IntEnum
+from pydantic import BaseModel
+from typing import (
+    Dict, 
+    List, 
+    Any, 
+    Literal, 
+    Optional, 
+    Union,
+    cast,
+    Type,
+    Tuple
+)
+
+from transformers import AutoModelForCausalLM
+
+from accelerate import dispatch_model
+
+from openai.types.model import Model
+from openai.types.chat import (
+    ChatCompletionMessageParam,
+    ChatCompletionToolChoiceOptionParam,
+)
+from openai.types.chat.chat_completion_message import FunctionCall
+from openai.types.chat.completion_create_params import ResponseFormat
+from openai.types.create_embedding_response import Usage
+
+
+# --------------- Pydantic v2 compatibility ---------------
+
+PYDANTIC_V2 = pydantic.VERSION.startswith("2.")
+
+
+def model_json(model: pydantic.BaseModel, **kwargs) -> str:
+    if PYDANTIC_V2:
+        return model.model_dump_json(**kwargs)
+    return model.json(**kwargs)  # type: ignore
+
+
+def model_dump(model: pydantic.BaseModel, **kwargs) -> Dict[str, Any]:
+    if PYDANTIC_V2:
+        return model.model_dump(**kwargs)
+    return cast(
+        "dict[str, Any]",
+        model.dict(**kwargs),
+    )
+
+
+def model_parse(model: Type[pydantic.BaseModel], data: Any) -> pydantic.BaseModel:
+    if PYDANTIC_V2:
+        return model.model_validate(data)
+    return model.parse_obj(data)  # pyright: ignore[reportDeprecated]
+
+
+def disable_warnings(model: Type[pydantic.BaseModel]):
+    # Disable warning for model_name settings
+    if PYDANTIC_V2:
+        model.model_config["protected_namespaces"] = ()
+
+def parse_messages(
+    messages: List[ChatCompletionMessageParam], split_role="user"
+) -> Tuple[str, List[List[ChatCompletionMessageParam]]]:
+    """
+    Parse a list of chat completion messages into system and rounds.
+
+    Args:
+        messages (List[ChatCompletionMessageParam]): The list of chat completion messages.
+        split_role: The role at which to split the rounds. Defaults to Role.USER.
+
+    Returns:
+        Tuple[str, List[List[ChatCompletionMessageParam]]]: A tuple containing the system message and a list of rounds.
+    """
+    system, rounds = "", []
+    r = []
+    for i, message in enumerate(messages):
+        if message["role"] == "system":
+            system = message["content"]
+            continue
+        if message["role"] == split_role and r:
+            rounds.append(r)
+            r = []
+        r.append(message)
+    if r:
+        rounds.append(r)
+    return system, rounds
+
+
+class Role(str, Enum):
+    USER = "user"
+    ASSISTANT = "assistant"
+    SYSTEM = "system"
+    FUNCTION = "function"
+    TOOL = "tool"
+
+
+class ErrorResponse(BaseModel):
+    object: str = "error"
+    message: str
+    code: int
+
+
+class ErrorCode(IntEnum):
+    """
+    https://platform.openai.com/docs/guides/error-codes/api-errors
+    """
+
+    VALIDATION_TYPE_ERROR = 40001
+
+    INVALID_AUTH_KEY = 40101
+    INCORRECT_AUTH_KEY = 40102
+    NO_PERMISSION = 40103
+
+    INVALID_MODEL = 40301
+    PARAM_OUT_OF_RANGE = 40302
+    CONTEXT_OVERFLOW = 40303
+
+    RATE_LIMIT = 42901
+    QUOTA_EXCEEDED = 42902
+    ENGINE_OVERLOADED = 42903
+
+    INTERNAL_ERROR = 50001
+    CUDA_OUT_OF_MEMORY = 50002
+    GRADIO_REQUEST_ERROR = 50003
+    GRADIO_STREAM_UNKNOWN_ERROR = 50004
+    CONTROLLER_NO_WORKER = 50005
+    CONTROLLER_WORKER_TIMEOUT = 50006
+
+
+class ModelList(BaseModel):
+    object: str = "list"
+    data: List[Model] = []
+
+
+class ChatCompletionCreateParams(BaseModel):
+    messages: List[ChatCompletionMessageParam]
+    """A list of messages comprising the conversation so far.
+
+    [Example Python code](https://cookbook.openai.com/examples/how_to_format_inputs_to_chatgpt_models).
+    """
+
+    model: str
+    """ID of the model to use.
+
+    See the
+    [model endpoint compatibility](https://platform.openai.com/docs/models/model-endpoint-compatibility)
+    table for details on which models work with the Chat API.
+    """
+
+    frequency_penalty: Optional[float] = 0.
+    """Number between -2.0 and 2.0.
+
+    Positive values penalize new tokens based on their existing frequency in the
+    text so far, decreasing the model's likelihood to repeat the same line verbatim.
+
+    [See more information about frequency and presence penalties.](https://platform.openai.com/docs/guides/gpt/parameter-details)
+    """
+
+    function_call: Optional[FunctionCall] = None
+    """Deprecated in favor of `tool_choice`.
+
+    Controls which (if any) function is called by the model. `none` means the model
+    will not call a function and instead generates a message. `auto` means the model
+    can pick between generating a message or calling a function. Specifying a
+    particular function via `{"name": "my_function"}` forces the model to call that
+    function.
+
+    `none` is the default when no functions are present. `auto`` is the default if
+    functions are present.
+    """
+
+    functions: Optional[List] = None
+    """Deprecated in favor of `tools`.
+
+    A list of functions the model may generate JSON inputs for.
+    """
+
+    logit_bias: Optional[Dict[str, int]] = None
+    """Modify the likelihood of specified tokens appearing in the completion.
+
+    Accepts a JSON object that maps tokens (specified by their token ID in the
+    tokenizer) to an associated bias value from -100 to 100. Mathematically, the
+    bias is added to the logits generated by the model prior to sampling. The exact
+    effect will vary per model, but values between -1 and 1 should decrease or
+    increase likelihood of selection; values like -100 or 100 should result in a ban
+    or exclusive selection of the relevant token.
+    """
+
+    max_tokens: Optional[int] = None
+    """The maximum number of [tokens](/tokenizer) to generate in the chat completion.
+
+    The total length of input tokens and generated tokens is limited by the model's
+    context length.
+    [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken)
+    for counting tokens.
+    """
+
+    n: Optional[int] = 1
+    """How many chat completion choices to generate for each input message."""
+
+    presence_penalty: Optional[float] = 0.
+    """Number between -2.0 and 2.0.
+
+    Positive values penalize new tokens based on whether they appear in the text so
+    far, increasing the model's likelihood to talk about new topics.
+
+    [See more information about frequency and presence penalties.](https://platform.openai.com/docs/guides/gpt/parameter-details)
+    """
+
+    response_format: Optional[ResponseFormat] = None
+    """An object specifying the format that the model must output.
+
+    Used to enable JSON mode.
+    """
+
+    seed: Optional[int] = None
+    """This feature is in Beta.
+
+    If specified, our system will make a best effort to sample deterministically,
+    such that repeated requests with the same `seed` and parameters should return
+    the same result. Determinism is not guaranteed, and you should refer to the
+    `system_fingerprint` response parameter to monitor changes in the backend.
+    """
+
+    stop: Optional[Union[str, List[str]]] = None
+    """Up to 4 sequences where the API will stop generating further tokens."""
+
+    temperature: Optional[float] = 0.9
+    """What sampling temperature to use, between 0 and 2.
+
+    Higher values like 0.8 will make the output more random, while lower values like
+    0.2 will make it more focused and deterministic.
+
+    We generally recommend altering this or `top_p` but not both.
+    """
+
+    tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None
+    """
+    Controls which (if any) function is called by the model. `none` means the model
+    will not call a function and instead generates a message. `auto` means the model
+    can pick between generating a message or calling a function. Specifying a
+    particular function via
+    `{"type: "function", "function": {"name": "my_function"}}` forces the model to
+    call that function.
+
+    `none` is the default when no functions are present. `auto` is the default if
+    functions are present.
+    """
+
+    tools: Optional[List] = None
+    """A list of tools the model may call.
+
+    Currently, only functions are supported as a tool. Use this to provide a list of
+    functions the model may generate JSON inputs for.
+    """
+
+    top_p: Optional[float] = 1.0
+    """
+    An alternative to sampling with temperature, called nucleus sampling, where the
+    model considers the results of the tokens with top_p probability mass. So 0.1
+    means only the tokens comprising the top 10% probability mass are considered.
+
+    We generally recommend altering this or `temperature` but not both.
+    """
+
+    user: Optional[str] = None
+    """
+    A unique identifier representing your end-user, which can help OpenAI to monitor
+    and detect abuse.
+    [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
+    """
+
+    stream: Optional[bool] = False
+    """If set, partial message deltas will be sent, like in ChatGPT.
+
+    Tokens will be sent as data-only
+    [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format)
+    as they become available, with the stream terminated by a `data: [DONE]`
+    message.
+    [Example Python code](https://cookbook.openai.com/examples/how_to_stream_completions).
+    """
+
+    # Addictional parameters
+    repetition_penalty: Optional[float] = 1.03
+    """The parameter for repetition penalty. 1.0 means no penalty.
+    See[this paper](https://arxiv.org / pdf / 1909.05858.pdf) for more details.
+    """
+
+    typical_p: Optional[float] = None
+    """Typical Decoding mass.
+    See[Typical Decoding for Natural Language Generation](https://arxiv.org / abs / 2202.00666) for more information
+    """
+
+    watermark: Optional[bool] = False
+    """Watermarking with [A Watermark for Large Language Models](https://arxiv.org / abs / 2301.10226)
+    """
+
+    best_of: Optional[int] = 1
+
+    ignore_eos: Optional[bool] = False
+
+    use_beam_search: Optional[bool] = False
+
+    stop_token_ids: Optional[List[int]] = None
+
+    skip_special_tokens: Optional[bool] = True
+
+    spaces_between_special_tokens: Optional[bool] = True
+
+    min_p: Optional[float] = 0.0
+
+
+class CompletionCreateParams(BaseModel):
+    model: str
+    """ID of the model to use.
+
+    You can use the
+    [List models](https://platform.openai.com/docs/api-reference/models/list) API to
+    see all of your available models, or see our
+    [Model overview](https://platform.openai.com/docs/models/overview) for
+    descriptions of them.
+    """
+
+    prompt: Union[str, List[str], List[int], List[List[int]], None]
+    """
+    The prompt(s) to generate completions for, encoded as a string, array of
+    strings, array of tokens, or array of token arrays.
+
+    Note that <|endoftext|> is the document separator that the model sees during
+    training, so if a prompt is not specified the model will generate as if from the
+    beginning of a new document.
+    """
+
+    best_of: Optional[int] = 1
+    """
+    Generates `best_of` completions server-side and returns the "best" (the one with
+    the highest log probability per token). Results cannot be streamed.
+
+    When used with `n`, `best_of` controls the number of candidate completions and
+    `n` specifies how many to return – `best_of` must be greater than `n`.
+
+    **Note:** Because this parameter generates many completions, it can quickly
+    consume your token quota. Use carefully and ensure that you have reasonable
+    settings for `max_tokens` and `stop`.
+    """
+
+    echo: Optional[bool] = False
+    """Echo back the prompt in addition to the completion"""
+
+    frequency_penalty: Optional[float] = 0.
+    """Number between -2.0 and 2.0.
+
+    Positive values penalize new tokens based on their existing frequency in the
+    text so far, decreasing the model's likelihood to repeat the same line verbatim.
+
+    [See more information about frequency and presence penalties.](https://platform.openai.com/docs/guides/gpt/parameter-details)
+    """
+
+    logit_bias: Optional[Dict[str, int]] = None
+    """Modify the likelihood of specified tokens appearing in the completion.
+
+    Accepts a JSON object that maps tokens (specified by their token ID in the GPT
+    tokenizer) to an associated bias value from -100 to 100. You can use this
+    [tokenizer tool](/tokenizer?view=bpe) (which works for both GPT-2 and GPT-3) to
+    convert text to token IDs. Mathematically, the bias is added to the logits
+    generated by the model prior to sampling. The exact effect will vary per model,
+    but values between -1 and 1 should decrease or increase likelihood of selection;
+    values like -100 or 100 should result in a ban or exclusive selection of the
+    relevant token.
+
+    As an example, you can pass `{"50256": -100}` to prevent the <|endoftext|> token
+    from being generated.
+    """
+
+    logprobs: Optional[int] = None
+    """
+    Include the log probabilities on the `logprobs` most likely tokens, as well the
+    chosen tokens. For example, if `logprobs` is 5, the API will return a list of
+    the 5 most likely tokens. The API will always return the `logprob` of the
+    sampled token, so there may be up to `logprobs+1` elements in the response.
+
+    The maximum value for `logprobs` is 5.
+    """
+
+    max_tokens: Optional[int] = 16
+    """The maximum number of [tokens](/tokenizer) to generate in the completion.
+
+    The token count of your prompt plus `max_tokens` cannot exceed the model's
+    context length.
+    [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken)
+    for counting tokens.
+    """
+
+    n: Optional[int] = 1
+    """How many completions to generate for each prompt.
+
+    **Note:** Because this parameter generates many completions, it can quickly
+    consume your token quota. Use carefully and ensure that you have reasonable
+    settings for `max_tokens` and `stop`.
+    """
+
+    presence_penalty: Optional[float] = 0.
+    """Number between -2.0 and 2.0.
+
+    Positive values penalize new tokens based on whether they appear in the text so
+    far, increasing the model's likelihood to talk about new topics.
+
+    [See more information about frequency and presence penalties.](https://platform.openai.com/docs/guides/gpt/parameter-details)
+    """
+
+    seed: Optional[int] = None
+    """
+    If specified, our system will make a best effort to sample deterministically,
+    such that repeated requests with the same `seed` and parameters should return
+    the same result.
+
+    Determinism is not guaranteed, and you should refer to the `system_fingerprint`
+    response parameter to monitor changes in the backend.
+    """
+
+    stop: Optional[Union[str, List[str]]] = None
+    """Up to 4 sequences where the API will stop generating further tokens.
+
+    The returned text will not contain the stop sequence.
+    """
+
+    suffix: Optional[str] = None
+    """The suffix that comes after a completion of inserted text."""
+
+    temperature: Optional[float] = 1.
+    """What sampling temperature to use, between 0 and 2.
+
+    Higher values like 0.8 will make the output more random, while lower values like
+    0.2 will make it more focused and deterministic.
+
+    We generally recommend altering this or `top_p` but not both.
+    """
+
+    top_p: Optional[float] = 1.
+    """
+    An alternative to sampling with temperature, called nucleus sampling, where the
+    model considers the results of the tokens with top_p probability mass. So 0.1
+    means only the tokens comprising the top 10% probability mass are considered.
+
+    We generally recommend altering this or `temperature` but not both.
+    """
+
+    user: Optional[str] = None
+    """
+    A unique identifier representing your end-user, which can help OpenAI to monitor
+    and detect abuse.
+    [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
+    """
+
+    stream: Optional[bool] = False
+    """If set, partial message deltas will be sent, like in ChatGPT.
+
+    Tokens will be sent as data-only
+    [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format)
+    as they become available, with the stream terminated by a `data: [DONE]`
+    message.
+    [Example Python code](https://cookbook.openai.com/examples/how_to_stream_completions).
+    """
+
+    # Addictional parameters
+    repetition_penalty: Optional[float] = 1.03
+    """The parameter for repetition penalty. 1.0 means no penalty.
+    See[this paper](https://arxiv.org / pdf / 1909.05858.pdf) for more details.
+    """
+
+    typical_p: Optional[float] = None
+    """Typical Decoding mass.
+    See[Typical Decoding for Natural Language Generation](https://arxiv.org / abs / 2202.00666) for more information
+    """
+
+    watermark: Optional[bool] = False
+    """Watermarking with [A Watermark for Large Language Models](https://arxiv.org / abs / 2301.10226)
+    """
+
+    ignore_eos: Optional[bool] = False
+
+    use_beam_search: Optional[bool] = False
+
+    stop_token_ids: Optional[List[int]] = None
+
+    skip_special_tokens: Optional[bool] = True
+
+    spaces_between_special_tokens: Optional[bool] = True
+
+    min_p: Optional[float] = 0.0
+
+
+class Embedding(BaseModel):
+    embedding: Any
+    """The embedding vector, which is a list of floats.
+
+    The length of vector depends on the model as listed in the
+    [embedding guide](https://platform.openai.com/docs/guides/embeddings).
+    """
+
+    index: int
+    """The index of the embedding in the list of embeddings."""
+
+    object: Literal["embedding"]
+    """The object type, which is always "embedding"."""
+
+
+class CreateEmbeddingResponse(BaseModel):
+    data: List[Embedding]
+    """The list of embeddings generated by the model."""
+
+    model: str
+    """The name of the model used to generate the embedding."""
+
+    object: Literal["list"]
+    """The object type, which is always "list"."""
+
+    usage: Usage
+    """The usage information for the request."""
+
+
+# Models don't use the same configuration key for determining the maximum
+# sequence length.  Store them here so we can sanely check them.
+# NOTE: The ordering here is important.  Some models have two of these, and we
+# have a preference for which value gets used.
+SEQUENCE_LENGTH_KEYS = [
+    "max_sequence_length",
+    "seq_length",
+    "max_position_embeddings",
+    "max_seq_len",
+    "model_max_length",
+]
+
+
+def get_context_length(config) -> int:
+    """ Get the context length of a model from a huggingface model config. """
+    rope_scaling = getattr(config, "rope_scaling", None)
+    rope_scaling_factor = config.rope_scaling["factor"] if rope_scaling else 1
+    for key in SEQUENCE_LENGTH_KEYS:
+        val = getattr(config, key, None)
+        if val is not None:
+            return int(rope_scaling_factor * val)
+    return 2048
+
+
+def apply_stopping_strings(reply: str, stop_strings: List[str]) -> Tuple[str, bool]:
+    """
+    Apply stopping strings to the reply and check if a stop string is found.
+
+    Args:
+        reply (str): The reply to apply stopping strings to.
+        stop_strings (List[str]): The list of stopping strings to check for.
+
+    Returns:
+        Tuple[str, bool]: A tuple containing the modified reply and a boolean indicating if a stop string was found.
+    """
+    stop_found = False
+    for string in stop_strings:
+        idx = reply.find(string)
+        if idx != -1:
+            reply = reply[:idx]
+            stop_found = True
+            break
+
+    if not stop_found:
+        # If something like "\nYo" is generated just before "\nYou: is completed, trim it
+        for string in stop_strings:
+            for j in range(len(string) - 1, 0, -1):
+                if reply[-j:] == string[:j]:
+                    reply = reply[:-j]
+                    break
+            else:
+                continue
+
+            break
+
+    return reply, stop_found
+
+
+
+
+
+def _device_map(num_gpus, num_layers):
+    per_gpu_layers = (num_layers + 2) / num_gpus
+
+    device_map = {
+        'transformer.wte': 0,
+        'transformer.ln_f': 0,
+        'lm_head': num_gpus-1
+    }
+
+    used = 1
+    gpu_target = 0
+    for i in range(num_layers):
+        if used >= per_gpu_layers:
+            gpu_target += 1
+            used = 0 if gpu_target < num_gpus-1 else 1
+        assert gpu_target < num_gpus
+        device_map[f'transformer.h.{i}'] = gpu_target
+        used += 1
+
+    return device_map
+
+
+def load_model_on_gpus(model_name_or_path, num_gpus: int = 2):
+    num_devices = torch.cuda.device_count()
+
+    if num_gpus == 1:
+        model = AutoModelForCausalLM.from_pretrained(model_name_or_path, device_map='auto',
+                                                     trust_remote_code=True).eval()
+    elif 1 < num_gpus <= num_devices:
+        model = AutoModelForCausalLM.from_pretrained(model_name_or_path, device_map='cpu',
+                                                     trust_remote_code=True).eval()
+        num_layers = model.config.num_hidden_layers
+        device_map = _device_map(num_gpus, num_layers)
+        print(device_map)
+        model = dispatch_model(model, device_map=device_map)
+    else:
+        raise KeyError
+
+    return model


### PR DESCRIPTION
#115 
尽管当前有许多推理框架支持了OpenAI API 协议的服务器部署(e.g. vLLM)，但它们往往都是复杂难调试的。一个独立的易理解的OpenAI API格式的本地API部署方法是需要的。多数开源模型都会提供相应的示例以方便开发者(e.g. qwen, chatglm)。

此PR支持了最新openai sdk(>= v1.0.0)的本地部署，支持流式与非流式并提供了请求示例。

Tested on 3090 Linux machine.  [code Implementation reference](https://github.com/xusenlinzy/api-for-open-llm/tree/master)